### PR TITLE
Browser detection fixes

### DIFF
--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -333,7 +333,7 @@ CodeInjection detect_browser_player_patch{
     [](auto& regs) {
         rf::Player* player = regs.esi;
         int conn_rate = regs.eax;
-        if (conn_rate == 1) {
+        if (conn_rate == 1 || conn_rate == 256) {
             auto& pdata = get_player_additional_data(player);
             pdata.is_browser = true;
         }

--- a/game_patch/multi/votes.cpp
+++ b/game_patch/multi/votes.cpp
@@ -436,6 +436,7 @@ void handle_vote_command(std::string_view vote_name, std::string_view vote_arg, 
 {
     if (get_player_additional_data(sender).is_browser) {
         send_chat_line_packet("Browsers are not allowed to vote!", sender);
+        return;
     }
     if (vote_name == "kick")
         g_vote_mgr.StartVote<VoteKick>(vote_arg, sender);


### PR DESCRIPTION
First, RfServerBrowser 5.1.4 uses a rate value of 256. Added this to the browser check.

Second, I fixed preventing browsers from voting - it was being checked but not blocked.