### PR TITLE
Use float instead of int for fps limit

### DIFF
--- a/game_patch/os/frametime.cpp
+++ b/game_patch/os/frametime.cpp
@@ -97,11 +97,11 @@ FunHook<void()> frametime_reset_hook{
 
 ConsoleCommand2 max_fps_cmd{
     "maxfps",
-    [](std::optional<float> limit_opt) {
+    [](std::optional<int> limit_opt) {
         if (limit_opt) {
-            float new_limit = limit_opt.value();
+            int new_limit = limit_opt.value();
 #if VERSION_TYPE != VERSION_TYPE_DEV
-            new_limit = std::clamp<float>(new_limit, GameConfig::min_fps_limit, GameConfig::max_fps_limit);
+            new_limit = std::clamp<int>(new_limit, GameConfig::min_fps_limit, GameConfig::max_fps_limit);
 #endif
             if (rf::is_dedicated_server) {
                 g_game_config.server_max_fps = new_limit;

--- a/game_patch/os/frametime.cpp
+++ b/game_patch/os/frametime.cpp
@@ -74,9 +74,9 @@ ConsoleCommand2 fps_counter_cmd{
     "fps_counter",
 };
 
-CallHook<void(int)> frametime_calculate_sleep_hook{
+CallHook<void(float)> frametime_calculate_sleep_hook{
     0x005095B4,
-    [](int ms) {
+    [](float ms) {
         --ms;
         if (ms > 0) {
             frametime_calculate_sleep_hook.call_target(ms);
@@ -97,11 +97,11 @@ FunHook<void()> frametime_reset_hook{
 
 ConsoleCommand2 max_fps_cmd{
     "maxfps",
-    [](std::optional<int> limit_opt) {
+    [](std::optional<float> limit_opt) {
         if (limit_opt) {
-            int new_limit = limit_opt.value();
+            float new_limit = limit_opt.value();
 #if VERSION_TYPE != VERSION_TYPE_DEV
-            new_limit = std::clamp<int>(new_limit, GameConfig::min_fps_limit, GameConfig::max_fps_limit);
+            new_limit = std::clamp<float>(new_limit, GameConfig::min_fps_limit, GameConfig::max_fps_limit);
 #endif
             if (rf::is_dedicated_server) {
                 g_game_config.server_max_fps = new_limit;


### PR DESCRIPTION
So there is a fork of dhewm3 which adds a command that allows for the game to be played at framerates above 62.5. One of the changes made to it's source code was using float instead of int for what is said to be for more precise fps limit. I have tried doing that here and there does seem to be an improvement. When limited to 120 which is my monitors refresh rate the screen tearing line jitters around less.