### PR TITLE
Update root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /dist
 /build*
 /research
+/out
 
 # Visual Studio
 *.sln
@@ -19,7 +20,7 @@ ipch
 .vscode
 CMakeSettings.json
 
-# Non-Open Source PF support code
+# Closed-source Pure Faction anti-cheat support code
 /game_patch/purefaction/*secret*
 
 # Experimental code


### PR DESCRIPTION
Each time I open my Dash Faction fork in Visual Studio 2022 for the first time, CMake generates a default, incompatible x64 build configuration. After I fix this and reconfigure the cache, it still attempts to use the default configuration and fails, finally switching over to the fixed one. But not before it creates a folder named "out" that contains some leftover files. So yeah, this one is for my own convenience.