### PR TITLE
Fix default RF game tracker not being replaced with the FF one in certain situations

### DIFF
--- a/common/src/config/GameConfig.cpp
+++ b/common/src/config/GameConfig.cpp
@@ -1,5 +1,6 @@
 #include <common/config/GameConfig.h>
 #include <common/config/RegKey.h>
+#include <common/version/version.h>
 #include <shlwapi.h>
 #include <algorithm>
 
@@ -20,6 +21,14 @@ bool GameConfig::load() try
 
     if (game_executable_path.value().empty() && !detect_game_path()) {
         game_executable_path = fallback_executable_path;
+    }
+
+    if (tracker.value() == "rf.thqmultiplay.net") {
+        if (dash_faction_version.value().empty() || dash_faction_version.value() != VERSION_STR) {
+            // Replace legacy tracker with the FactionFiles one if the tracker is unconfigured or the Dash version is different
+            tracker = default_rf_tracker;
+            dash_faction_version = VERSION_STR;
+        }
     }
 
     if (update_rate == 0) {

--- a/launcher/LauncherApp.cpp
+++ b/launcher/LauncherApp.cpp
@@ -37,9 +37,6 @@ int LauncherApp::Run()
         return 0;
     }
 
-    // Migrate Dash Faction config from old version
-    MigrateConfig();
-
     // Disable elevation (UAC)
     SetEnvironmentVariableA("__COMPAT_LAYER", "RunAsInvoker");
 
@@ -62,23 +59,6 @@ int LauncherApp::Run()
 
     xlog::info("Closing the launcher");
 	return 0;
-}
-
-void LauncherApp::MigrateConfig()
-{
-    try {
-        GameConfig config;
-        if (config.load() && config.dash_faction_version.value() != VERSION_STR) {
-            xlog::info("Migrating config");
-            if (config.tracker.value() == "rf.thqmultiplay.net" && config.dash_faction_version->empty()) // < 1.1.0
-                config.tracker = GameConfig::default_rf_tracker;
-            config.dash_faction_version = VERSION_STR;
-            config.save();
-        }
-    }
-    catch (std::exception&) {
-        // ignore
-    }
 }
 
 bool LauncherApp::LaunchGame(HWND hwnd, const char* mod_name)


### PR DESCRIPTION
With this hotfix, the FF game tracker should now correctly replace the default one, even if the user had set their tracker setting in the vanilla game prior to using Dash. 

Addresses a concern brought up in #216.