### PR TITLE
Fix items in multiplayer being very dark in some cases on first load

### DIFF
--- a/game_patch/object/obj_light.cpp
+++ b/game_patch/object/obj_light.cpp
@@ -45,8 +45,7 @@ static bool obj_should_be_lit(rf::Object *objp)
         return false;
     }
     // Clutter object always use static lighting
-    // Items does only in single-player. In multi-player they spins so static lighting make less sense
-    return objp->type == rf::OT_CLUTTER || (objp->type == rf::OT_ITEM && !rf::is_multi);
+    return objp->type == rf::OT_CLUTTER || objp->type == rf::OT_ITEM;
 }
 
 void obj_mesh_lighting_maybe_update(rf::Object *objp)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3c989e9e-9302-4bf8-98ff-d6050ba04e6b)

(excuse the crude MS paint diagram)
The diagram above shows the effect of this change, screenshots were taken in dm15 (as a client).

In the current state (without this change), if you have mesh static lighting turned on, when the map loads, items are very dark. If you toggle mesh static lighting off and then back on while the map is already loaded, the items are then rendered as you would expect them to be.

With this change, meshes are displayed properly when the map is first loaded, without needing the player to toggle mesh static lighting off and on to fix them.

In the diagram, the item looks the same in the middle (mesh static lighting toggled off) and right side (mesh static lighting toggled back on) between current state and after this change. The only difference is on initial load, where with this PR they look right but in the current state they are very dark.