### PR TITLE
Add support for client_mods folder + allow clientside mods to edit safe tbl files

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,7 @@ Version 1.9.0 (not released yet)
 - Add Kill Reward settings for dedicated servers
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
+- Allow clientside mods to edit table files that can't be used to cheat (strings, hud, hud_personas, personas, credits, endgame, ponr)
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@ Version 1.9.0 (not released yet)
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
 - Allow clientside mods to edit table files that can't be used to cheat (strings, hud, hud_personas, personas, credits, endgame, ponr)
+- Add support for `client_mods` folder for loading clientside mods and made launcher switch restore legacy behavior
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
 
 Version 1.8.0 (released 2022-09-17)

--- a/game_patch/misc/misc.cpp
+++ b/game_patch/misc/misc.cpp
@@ -45,6 +45,11 @@ bool g_in_mp_game = false;
 bool g_jump_to_multi_server_list = false;
 std::optional<JoinMpGameData> g_join_mp_game_seq_data;
 
+bool tc_mod_is_loaded()
+{
+    return rf::mod_param.found();
+}
+
 CodeInjection critical_error_hide_main_wnd_patch{
     0x0050BA90,
     []() {
@@ -381,7 +386,7 @@ CodeInjection vfile_read_stack_corruption_fix{
 CodeInjection game_set_file_paths_injection{
     0x004B1810,
     []() {
-        if (rf::mod_param.found()) {
+        if (tc_mod_is_loaded()) {
             std::string mod_dir = "mods\\";
             mod_dir += rf::mod_param.get_arg();
             rf::file_add_path(mod_dir.c_str(), ".bik", false);

--- a/game_patch/misc/misc.h
+++ b/game_patch/misc/misc.h
@@ -10,3 +10,4 @@ void start_join_multi_game_sequence(const rf::NetAddr& addr, const std::string& 
 bool multi_join_game(const rf::NetAddr& addr, const std::string& password);
 void ui_get_string_size(int* w, int* h, const char* s, int s_len, int font_num);
 void g_solid_render_ui();
+bool tc_mod_is_loaded();

--- a/game_patch/misc/vpackfile.cpp
+++ b/game_patch/misc/vpackfile.cpp
@@ -321,6 +321,9 @@ static bool is_lookup_table_entry_override_allowed(rf::VPackfileEntry* old_entry
         // Allow overriding by packfiles from game root and from mods
         return true;
     }
+    if (!g_game_config.allow_overwrite_game_files) {
+        return false;
+    }
     if (!old_entry->parent->is_user_maps && is_tbl_file_in_allowlist(new_entry->name)) {
         // Allow overriding of tbl files from user_maps if they are on allow list
         return true;
@@ -335,9 +338,6 @@ static bool is_lookup_table_entry_override_allowed(rf::VPackfileEntry* old_entry
         return true;
     }
 #endif
-    if (!g_game_config.allow_overwrite_game_files) {
-        return false;
-    }
     g_is_modded_game = true;
     return true;
 }

--- a/game_patch/misc/vpackfile.cpp
+++ b/game_patch/misc/vpackfile.cpp
@@ -321,6 +321,12 @@ static bool is_lookup_table_entry_override_allowed(rf::VPackfileEntry* old_entry
         // Allow overriding by packfiles from game root and from mods
         return true;
     }
+#ifdef MOD_FILE_WHITELIST
+    if (is_mod_file_in_whitelist(new_entry->name)) {
+        // Always allow overriding for specific files
+        return true;
+    }
+#endif
     if (!g_game_config.allow_overwrite_game_files) {
         return false;
     }
@@ -332,12 +338,6 @@ static bool is_lookup_table_entry_override_allowed(rf::VPackfileEntry* old_entry
         // Skip overriding of all other tbl files from user_maps
         return false;
     }
-#ifdef MOD_FILE_WHITELIST
-    if (is_mod_file_in_whitelist(new_entry->name)) {
-        // Always allow overriding for specific files
-        return true;
-    }
-#endif
     g_is_modded_game = true;
     return true;
 }

--- a/game_patch/misc/vpackfile.cpp
+++ b/game_patch/misc/vpackfile.cpp
@@ -68,36 +68,37 @@ static bool is_mod_file_in_whitelist(const char* Filename)
 
 // allow list of table files that can't be used for cheating, but for which modding in clientside mods has utility
 // Examples include translation packs (translated strings, endgame, etc.) and custom HUD mods that change coords of HUD elements
-const char* tbl_mod_allow_list[] = {
+constexpr std::array<std::string_view, 7> tbl_mod_allow_list = {
     "strings.tbl",
     "hud.tbl",
     "hud_personas.tbl",
     "personas.tbl",
     "credits.tbl",
     "endgame.tbl",
-    "ponr.tbl",
+    "ponr.tbl"
 };
 
-static bool is_tbl_file(const char* Filename)
+static bool is_tbl_file(const char* filename)
 {
-    if (stricmp(rf::file_get_ext(Filename), ".tbl") == 0) {
+    // confirm we're working with a tbl file
+    if (stricmp(rf::file_get_ext(filename), ".tbl") == 0) {
         return true;
     }
     return false;
 }
 
-static bool is_tbl_file_in_allowlist(const char* Filename)
+static bool is_tbl_file_in_allowlist(const char* filename)
 {
-    for (unsigned i = 0; i < std::size(tbl_mod_allow_list); ++i)
-        if (is_tbl_file(Filename) && !stricmp(tbl_mod_allow_list[i], Filename))
-            return true;
-    return false;
+    // compare the input file against the tbl file allowlist
+    return is_tbl_file(filename) && std::ranges::any_of(tbl_mod_allow_list, [filename](std::string_view allowed_tbl) {
+               return stricmp(allowed_tbl.data(), filename) == 0;
+           });
 }
 
-static bool is_tbl_file_a_hud_messages_file(const char* Filename)
+static bool is_tbl_file_a_hud_messages_file(const char* filename)
 {
     // check if the input file ends with "_text.tbl"
-    if (strlen(Filename) >= 9 && stricmp(Filename + strlen(Filename) - 9, "_text.tbl") == 0) {
+    if (strlen(filename) >= 9 && stricmp(filename + strlen(filename) - 9, "_text.tbl") == 0) {
         return true;
     }
     return false;

--- a/game_patch/rf/file/file.h
+++ b/game_patch/rf/file/file.h
@@ -98,6 +98,7 @@ namespace rf
 
     static auto& file_get_ext = addr_as_ref<char*(const char *path)>(0x005143F0);
     static auto& file_add_path = addr_as_ref<int(const char *path, const char *exts, bool search_on_cd)>(0x00514070);
+    //static auto& game_add_path = addr_as_ref<int(const char* path, const char* exts)>(0x004B1330);
 
     static auto& root_path = addr_as_ref<char[max_path_len]>(0x018060E8);
 }

--- a/game_patch/rf/file/packfile.h
+++ b/game_patch/rf/file/packfile.h
@@ -20,7 +20,9 @@ namespace rf
 #endif
         uint32_t file_size;
 #ifdef DASH_FACTION
+        // track whether the packfile was from user_maps or client_mods
         bool is_user_maps;
+        bool is_client_mods;
 #endif
     };
 #ifndef DASH_FACTION
@@ -46,6 +48,6 @@ namespace rf
     using VPackfileAddEntries_Type = uint32_t(VPackfile* packfile, const void* buf, unsigned num_files_in_block,
                                               unsigned* num_added);
     static auto& vpackfile_add_entries = addr_as_ref<VPackfileAddEntries_Type>(0x0052BD40);
-
-    static auto& vpackfile_loading_user_maps = addr_as_ref<bool>(0x01BDB21C);
+    // handled directly in vpackfile_add_new
+    //static auto& vpackfile_loading_user_maps = addr_as_ref<bool>(0x01BDB21C);
 }

--- a/launcher/DashFactionLauncher.rc
+++ b/launcher/DashFactionLauncher.rc
@@ -154,7 +154,7 @@ STYLE DS_SHELLFONT | WS_CHILD | WS_VISIBLE | DS_CONTROL
 FONT 8, "MS Shell Dlg"
 BEGIN
     AUTOCHECKBOX    "Fast Start",IDC_FAST_START_CHECK,0,0,66,10
-    AUTOCHECKBOX    "Allow overriding game files by packages in user_maps",IDC_ALLOW_OVERWRITE_GAME_CHECK,0,12,260,10
+    AUTOCHECKBOX    "Allow clientside mods to be loaded from user_maps",IDC_ALLOW_OVERWRITE_GAME_CHECK,0,12,260,10
     AUTOCHECKBOX    "Run game at reduced speed when window doesn't have focus",IDC_REDUCED_SPEED_IN_BG_CHECK,0,24,260,10
     AUTOCHECKBOX    "Beep when another player joins multiplayer game and window doesn't have focus",
                     IDC_PLAYER_JOIN_BEEP_CHECK,0,36,260,18,BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP | BS_TOP

--- a/launcher/OptionsMiscDlg.cpp
+++ b/launcher/OptionsMiscDlg.cpp
@@ -25,7 +25,7 @@ void OptionsMiscDlg::InitToolTip()
 {
     m_tool_tip.Create(*this);
     m_tool_tip.AddTool(GetDlgItem(IDC_FAST_START_CHECK), "Skip game intro videos and go straight to Main Menu");
-    m_tool_tip.AddTool(GetDlgItem(IDC_ALLOW_OVERWRITE_GAME_CHECK), "Enable this if you want to modify game content by putting mods into user_maps folder. Can have side effect of level packfiles modyfing common textures/sounds.");
+    m_tool_tip.AddTool(GetDlgItem(IDC_ALLOW_OVERWRITE_GAME_CHECK), "Allows files in user_maps folders to override core game files. When left disabled, only files in client_mods can do this. Enabling this can unintentionally mean stock game assets get replaced by installed levels.");
     m_tool_tip.AddTool(GetDlgItem(IDC_AUTOSAVE_CHECK), "Automatically save the game after a level transition");
 }
 


### PR DESCRIPTION
I've revamped this PR extensively since it was first put in. All the changes are detailed below, and I've also commented the code as much as possible.
Resolves #63 
Resolves #62 

Functionality:
- Add support for a "client_mods" folder in the root RF directory. This folder is intended to be used by client_side mods, as opposed to the current/historical approach of using user_maps folders (which are _supposed_ to be for levels) being used for this purpose.
- Renamed the user_maps switch in the launcher, revised the tooltip, and made it effectively serve the role of a "legacy compatibility" switch. Most users should leave this unticked (default), but if someone wants to use the historical approach of dropping clientside mods in user_maps, they can turn it on (as they have to already).
- Added a tbl file allow list which allows clientside mods to override tbl files that _cannot be used for cheating_. 

This is a pretty extensive change. I've done a huge amount of testing of various scenarios and from everything I have seen it works absolutely perfectly as-is, but especially given how extensive it is, I would **really** appreciate some extra eyes on it so any potential regressions or odd behaviours are identified and mitigated before it's merged. The most extensive changes are:
- Overhauled the asset override logic entirely (`is_lookup_table_entry_override_allowed` in `vpackfile.cpp`)
- Rewrote `load_additional_packfiles` function as `load_additional_packfiles_new` in `vpackfile.cpp`

Main benefits of this change are:
- Allows custom HUDs which adjust the positions of HUD elements. Currently such mods must be run as TC mods, after this change they can be run as clientside mods.
- Allows translation mods (which edit strings.tbl, etc.) to be packaged as clientside mods, enhancing RF's accessibility to non-English speaking people (since they can play multiplayer with everyone else while having their translation mod loaded).
- Having a separate folder for client_mods makes more logical sense, is nicer for organization, and means people can use the launcher user_maps switch to avoid unintentionally overriding core game assets without impacting their ability to use clientside mods intentionally.


tbl files that as of this PR will be able to be changed via client_side mods are:
- Anything that ends with _text.tbl (HUD message config files)
- strings.tbl
- hud.tbl
- hud_personas.tbl
- personas.tbl
- credits.tbl
- endgame.tbl
- ponr.tbl