### PR TITLE
Fix bugs with click limiter and add configurable semi-auto CPS limit to dedicated server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Configuration example:
     // 3 - client-side mods are disallowed (gold P symbol in Pure Faction)
     //$DF Anticheat Level: 0
     // Set click limit for semi-automatic weapons (pistol and precision rifle). Bullets fired quicker than this rate will be ignored. Can be used to lessen impact of autoclicker cheats.
-    $DF Semi Auto Click Limit: 20.0
+    $DF Semi Auto Click Rate Limit: 20.0
     // If true and server is using a mod (-mod command line argument) then client is required to use the same mod
     // Can be disabled to allow publicly available modded servers
     $DF Require Client Mod: true

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Configuration example:
     // 2 - essential game parameters must match (blue P symbol in Pure Faction)
     // 3 - client-side mods are disallowed (gold P symbol in Pure Faction)
     //$DF Anticheat Level: 0
+    // Set click limit for semi-automatic weapons (pistol and precision rifle). Bullets fired quicker than this rate will be ignored. Can be used to lessen impact of autoclicker cheats.
+    $DF Semi Auto Click Limit: 20.0
     // If true and server is using a mod (-mod command line argument) then client is required to use the same mod
     // Can be disabled to allow publicly available modded servers
     $DF Require Client Mod: true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,7 +43,7 @@ Version 1.9.0 (not released yet)
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
 - Fix some fire packets being wrongfully dropped by click limiter (DF bug)
-- Add `$DF Semi Auto Click Limit` option in dedicated server config
+- Add `$DF Semi Auto Click Rate Limit` option in dedicated server config
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,7 +42,7 @@ Version 1.9.0 (not released yet)
 - Add Kill Reward settings for dedicated servers
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
-- Fixed some fire packets being wrongfully dropped by click limiter (DF bug)
+- Fix some fire packets being wrongfully dropped by click limiter (DF bug)
 - Add `$DF Semi Auto Click Limit` option in dedicated server config
 
 Version 1.8.0 (released 2022-09-17)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,8 @@ Version 1.9.0 (not released yet)
 - Add Kill Reward settings for dedicated servers
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
+- Fixed some fire packets being wrongfully dropped by click limiter (DF bug)
+- Add `$DF Semi Auto Click Limit` option in dedicated server config
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/multi/multi.cpp
+++ b/game_patch/multi/multi.cpp
@@ -296,7 +296,7 @@ float multi_get_max_cps(int weapon_type)
 
 void send_private_message_for_cancelled_shot(rf::Player* player, const std::string& reason)
 {
-    auto message = std::format("Shot cancelled! {}", reason);
+    auto message = std::format("\xA6 Shot canceled! {}", reason);
     send_chat_line_packet(message.c_str(), player);
 }
 
@@ -305,11 +305,11 @@ bool multi_check_cps(rf::Player* pp, int weapon_type)
     float max_cps = multi_get_max_cps(weapon_type);
     auto [above_limit, cps] = multi_is_cps_above_limit(pp, max_cps, weapon_type);
     if (above_limit) {
-        xlog::info("Cancelled fire request from player {} for weapon {}. They are shooting too fast: cps {:.2f} is greater than allowed {:.2f}",
+        xlog::info("Canceled fire request from player {} for weapon {}. They are shooting too fast: cps {:.2f} is greater than allowed {:.2f}",
             pp->name, weapon_type, cps, max_cps);
 
         // inform the player
-        send_private_message_for_cancelled_shot(pp, std::format("You are shooting too quickly. Your CPS: {:.2f}, Max CPS: {:.2f}.",
+        send_private_message_for_cancelled_shot(pp, std::format("You are shooting too fast. Your CPS: {:.2f}, Max CPS: {:.2f}.",
             cps, max_cps));
     }
     return above_limit;

--- a/game_patch/multi/multi.cpp
+++ b/game_patch/multi/multi.cpp
@@ -251,18 +251,18 @@ std::pair<bool, float> multi_is_cps_above_limit(rf::Player* pp, float max_cps, i
     constexpr int num_samples = 4;
     int player_id = pp->net_data->player_id;
     static int last_weapon_id[rf::multi_max_player_id];         // Keep a record of last weapon used
-    static bool last_weapon_fire_mode[rf::multi_max_player_id]; // Keep a record of last fire mode used
+    static bool last_weapon_is_alt_fire[rf::multi_max_player_id]; // Keep a record of last fire mode used
     static int last_weapon_fire[rf::multi_max_player_id][num_samples];
     int now = rf::timer_get(1000);
     // If the weapon or fire mode has changed, zero out the saved array of timestamps. Avoids dropping legit fire packets based on cps from other weapon/firemode
-    if (last_weapon_id[player_id] != weapon_type || last_weapon_fire_mode[player_id] != alt_fire) {
+    if (last_weapon_id[player_id] != weapon_type || last_weapon_is_alt_fire[player_id] != alt_fire) {
         xlog::debug("Player %i swapped weapon to %i", player_id, weapon_type);
         xlog::debug("Player %i swapped fire mode to %i", player_id, alt_fire);
         for (int i = 0; i < num_samples; ++i) {
             last_weapon_fire[player_id][i] = 0;
         }
         last_weapon_id[player_id] = weapon_type; // Update the last weapon used
-        last_weapon_fire_mode[player_id] = alt_fire; // Update the last fire mode used
+        last_weapon_is_alt_fire[player_id] = alt_fire; // Update the last fire mode used
     }
     float avg_dt_secs = (now - last_weapon_fire[player_id][0]) / static_cast<float>(num_samples) / 1000.0f;
     float cps = 1.0f / avg_dt_secs;

--- a/game_patch/multi/multi.cpp
+++ b/game_patch/multi/multi.cpp
@@ -309,7 +309,7 @@ bool multi_check_cps(rf::Player* pp, int weapon_type)
             pp->name, weapon_type, cps, max_cps);
 
         // inform the player
-        send_private_message_for_cancelled_shot(pp, std::format("You are shooting too fast. Your CPS: {:.2f}, Max CPS: {:.2f}.",
+        send_private_message_for_cancelled_shot(pp, std::format("You are shooting too fast. Your fire rate: {:.1f}, Server maximum: {:.1f}",
             cps, max_cps));
     }
     return above_limit;

--- a/game_patch/multi/multi.cpp
+++ b/game_patch/multi/multi.cpp
@@ -320,7 +320,8 @@ bool multi_is_weapon_fire_allowed_server_side(rf::Entity *ep, int weapon_type, b
     rf::Player* pp = rf::player_from_entity_handle(ep->handle);
     if (ep->ai.current_primary_weapon != weapon_type) {
         xlog::debug("Player {} attempted to fire unselected weapon {}", pp->name, weapon_type);
-        send_private_message_for_cancelled_shot(pp, "You attempted to fire an unselected weapon.");
+        // causes spam if player fires immediately when they die
+        //send_private_message_for_cancelled_shot(pp, "You attempted to fire an unselected weapon.");
     }
     else if (is_entity_out_of_ammo(ep, weapon_type, alt_fire)) {
         xlog::debug("Player {} attempted to fire weapon {} without ammunition", pp->name, weapon_type);
@@ -336,7 +337,9 @@ bool multi_is_weapon_fire_allowed_server_side(rf::Entity *ep, int weapon_type, b
     }
     else if (rf::entity_is_reloading(ep)) {
         xlog::debug("Player {} attempted to fire weapon {} while reloading it", pp->name, weapon_type);
-        send_private_message_for_cancelled_shot(pp, "You attempted to fire while reloading.");
+        // a bug causes shotgun shots to be cancelled shortly after reloading
+        // needs to be fixed but for right now reducing chat spam by removing the notification
+        //send_private_message_for_cancelled_shot(pp, "You attempted to fire while reloading.");
     }
     else if (!multi_check_cps(pp, weapon_type)) {
         return true;

--- a/game_patch/multi/multi.cpp
+++ b/game_patch/multi/multi.cpp
@@ -266,7 +266,6 @@ std::pair<bool, float> multi_is_cps_above_limit(rf::Player* pp, float max_cps, i
     }
     float avg_dt_secs = (now - last_weapon_fire[player_id][0]) / static_cast<float>(num_samples) / 1000.0f;
     float cps = 1.0f / avg_dt_secs;
-    xlog::debug("Current cps %f, based on current avg_dt_secs %f", cps, avg_dt_secs);
     if (cps > max_cps) {
         return {true, cps};
     }

--- a/game_patch/multi/multi.cpp
+++ b/game_patch/multi/multi.cpp
@@ -290,7 +290,7 @@ float multi_get_max_cps(int weapon_type)
     float fire_wait_secs = fire_wait_ms / 1000.0f;
     float fire_rate = 1.0f / fire_wait_secs;
     // allow 10% more to make sure we do not skip any legit packets
-    xlog::debug("For fire request for weapon %i, max cps is %.2f", weapon_type, fire_rate*1.1f);
+    xlog::debug("For fire request for weapon {}, max cps is {:.2f}", weapon_type, fire_rate*1.1f);
     return fire_rate * 1.1f;
 }
 
@@ -299,7 +299,7 @@ bool multi_check_cps(rf::Player* pp, int weapon_type)
     float max_cps = multi_get_max_cps(weapon_type);
     auto [above_limit, cps] = multi_is_cps_above_limit(pp, max_cps, weapon_type);
     if (above_limit) {
-        xlog::info(""Cancelled fire request from player {} for weapon {}. They are shooting too fast: cps {:.2f} is greater than allowed {:.2f}",
+        xlog::info("Cancelled fire request from player {} for weapon {}. They are shooting too fast: cps {:.2f} is greater than allowed {:.2f}",
             pp->name, weapon_type, cps, max_cps);
     }
     return above_limit;

--- a/game_patch/multi/multi.cpp
+++ b/game_patch/multi/multi.cpp
@@ -309,7 +309,7 @@ bool multi_check_cps(rf::Player* pp, int weapon_type)
             pp->name, weapon_type, cps, max_cps);
 
         // inform the player
-        send_private_message_for_cancelled_shot(pp, std::format("You are shooting too fast. Your fire rate: {:.1f}, Server maximum: {:.1f}",
+        send_private_message_for_cancelled_shot(pp, std::format("You are shooting too fast. Your fire rate: {:.1f}, server maximum: {:.1f}",
             cps, max_cps));
     }
     return above_limit;

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -129,8 +129,8 @@ void load_additional_server_config(rf::Parser& parser)
         g_additional_server_config.anticheat_level = parser.parse_int();
     }
 
-    if (parser.parse_optional("$DF Semi Auto Click Rate Limit:")) {
-        g_additional_server_config.click_limiter_max_cps = parser.parse_float();
+    if (parser.parse_optional("$DF Semi Auto Minimum Fire Wait:")) {
+        g_additional_server_config.click_limiter_fire_wait = parser.parse_int();
     }
 
     if (parser.parse_optional("$DF Require Client Mod:")) {

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -127,7 +127,7 @@ void load_additional_server_config(rf::Parser& parser)
         g_additional_server_config.anticheat_level = parser.parse_int();
     }
 
-    if (parser.parse_optional("$DF Semi Auto Click Limit:")) {
+    if (parser.parse_optional("$DF Semi Auto Click Rate Limit:")) {
         g_additional_server_config.click_limiter_max_cps = parser.parse_float();
     }
 

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -127,6 +127,10 @@ void load_additional_server_config(rf::Parser& parser)
         g_additional_server_config.anticheat_level = parser.parse_int();
     }
 
+    if (parser.parse_optional("$DF Semi Auto Click Limit:")) {
+        g_additional_server_config.click_limiter_max_cps = parser.parse_float();
+    }
+
     if (parser.parse_optional("$DF Require Client Mod:")) {
         g_additional_server_config.require_client_mod = parser.parse_bool();
     }

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -48,7 +48,7 @@ struct ServerAdditionalConfig
     std::optional<int> force_player_character;
     std::optional<float> max_fov;
     int anticheat_level = 0;
-    float click_limiter_max_cps = 20.0f;
+    int click_limiter_fire_wait = 50;
     bool stats_message_enabled = true;
     std::string welcome_message;
     bool weapon_items_give_full_ammo = false;

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -48,6 +48,7 @@ struct ServerAdditionalConfig
     std::optional<int> force_player_character;
     std::optional<float> max_fov;
     int anticheat_level = 0;
+    float click_limiter_max_cps = 20.0f;
     bool stats_message_enabled = true;
     std::string welcome_message;
     bool weapon_items_give_full_ammo = false;


### PR DESCRIPTION
This PR adds a "$DF Semi Auto Click Limit" configurable option to dedicated_server.txt and documents its usage. This option allows server operators to set a max cps value to be used for semi auto weapons, and gives them an additional tool in combatting autoclicking cheating, to a threshold they are comfortable with, rather than forcing a specific threshold on all server operators. The default used if this option is not specified is 20, which is already the default in Dash for semi auto weapons.

A click limiter like this is something that has long been requested by server operators and players, including a mention in #256 ("pr rate limiter").

This PR also fixes the following bugs:
1. Before this change, if a player held primary fire with baton for a few swings, cps would exceed max cps based on fire wait from weapons.tbl, and some fire packets would be dropped. I'm guessing this is because the fire wait in weapons.tbl doesn't consider that it fires "twice"(?) Fix in this PR is to base max cps for baton on 2.2x weapons.tbl fire wait rather than 1.1x like for other automatic weapons.
2. Before this change, if a player drummed pistol rapidly then swapped quickly to another weapon (rail, for example), very often the first fire packet would be dropped because it considered the cps from when they were drumming the pistol and compared against the max cps based on the rail's fire wait from weapons.tbl. Fix in this PR is to track weapon IDs when determining if max cps is met, and zero out the tracked timestamps when they fire a new weapon.
3. Before this change, if a player held shotgun alt fire for 6 shots, then immediately hit primary fire, the primary fire packet would be dropped because it used the cps from when they were using alt fire and compared against the max cps based on the primary fire's fire wait from weapons.tbl. Fix in this PR is to track weapon fire mode (primary/alt) when determining if max cps is met, and zero out the tracked timestamps when they use a new fire mode.

I didn't set out to find these bugs - I found and fixed them while I was implementing the feature. Testing this feature is how I found the second bug listed above, which led me to the others. I could break these fixes out into a PR separate from the feature if you like (let me know), but given that I fixed them while working on this, and that the fixes should (I think?) be uncontroversial, I thought it made sense to submit them together.