### PR TITLE
Add random map selection command, vote type, and dedicated server config item to randomize server rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Name                     | Description
 `map_ext`                | extend round
 `map_rest`               | restart current level
 `map_next`               | load next level
+`map_next`               | load random level from rotation
 `map_prev`               | load previous level
 `kill_limit value`       | set kill limit
 `time_limit value`       | set time limit

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Name                     | Description
 `map_ext`                | extend round
 `map_rest`               | restart current level
 `map_next`               | load next level
-`map_next`               | load random level from rotation
+`map_rand`               | load random level from rotation
 `map_prev`               | load previous level
 `kill_limit value`       | set kill limit
 `time_limit value`       | set time limit

--- a/README.md
+++ b/README.md
@@ -193,9 +193,7 @@ Configuration example:
     $DF Force Player Character: "enviro_parker"
     // Maximal horizontal FOV that clients can use for level rendering (unlimited by default)
     //$DF Max FOV: 125
-    // Instead of loading levels in order, load a random level from the configured level list after each round (only applies when round ends due to kill, cap, or time limit)
-    $DF Random Level Order: false
-    // When the level rotation finishes, shuffle the list of levels before starting the rotation again
+    // Shuffle the list of levels when the server starts and at the end of each full rotation
     $DF Dynamic Rotation: false
     // If enabled a private message with player statistics is sent after each round.
     //$DF Send Player Stats Message: true

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Name                     | Description
 `map_next`               | load next level
 `map_rand`               | load random level from rotation
 `map_prev`               | load previous level
-`shuffle_maps`           | shuffle the order of upcoming levels
 `kill_limit value`       | set kill limit
 `time_limit value`       | set time limit
 `geomod_limit value`     | set geomod limit

--- a/README.md
+++ b/README.md
@@ -188,8 +188,10 @@ Configuration example:
     $DF Player Damage Modifier: 1.0
     // Enable '/save' and '/load' chat commands (works for all clients) and quick save/load controls handling (works for Dash Faction 1.5.0+ clients). Option designed with run-maps in mind.
     $DF Saving Enabled: false
-    // Instead of loading levels in order, load a random level from the rotation after each round (only applies when round ends due to kill, cap, or time limit)
+    // Instead of loading levels in order, load a random level from the configured level list after each round (only applies when round ends due to kill, cap, or time limit)
     $DF Random Level Order: false
+    // When the level rotation finishes, shuffle the list of levels before starting the rotation again
+    $DF Dynamic Rotation: false
     // Enable Universal Plug-and-Play (enabled by default)
     $DF UPnP Enabled: true
     // Force all players to use the same character (check pc_multi.tbl for valid names)

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Configuration example:
     // Enable '/save' and '/load' chat commands (works for all clients) and quick save/load controls handling (works for Dash Faction 1.5.0+ clients). Option designed with run-maps in mind.
     $DF Saving Enabled: false
     // Randomize the order of levels in the server rotation (instead of loading them sequentially)
-    $DF Randomize Rotation: false
+    $DF Random Level Order: false
     // Enable Universal Plug-and-Play (enabled by default)
     $DF UPnP Enabled: true
     // Force all players to use the same character (check pc_multi.tbl for valid names)

--- a/README.md
+++ b/README.md
@@ -187,16 +187,16 @@ Configuration example:
     $DF Player Damage Modifier: 1.0
     // Enable '/save' and '/load' chat commands (works for all clients) and quick save/load controls handling (works for Dash Faction 1.5.0+ clients). Option designed with run-maps in mind.
     $DF Saving Enabled: false
-    // Instead of loading levels in order, load a random level from the configured level list after each round (only applies when round ends due to kill, cap, or time limit)
-    $DF Random Level Order: false
-    // When the level rotation finishes, shuffle the list of levels before starting the rotation again
-    $DF Dynamic Rotation: false
     // Enable Universal Plug-and-Play (enabled by default)
     $DF UPnP Enabled: true
     // Force all players to use the same character (check pc_multi.tbl for valid names)
     $DF Force Player Character: "enviro_parker"
     // Maximal horizontal FOV that clients can use for level rendering (unlimited by default)
     //$DF Max FOV: 125
+    // Instead of loading levels in order, load a random level from the configured level list after each round (only applies when round ends due to kill, cap, or time limit)
+    $DF Random Level Order: false
+    // When the level rotation finishes, shuffle the list of levels before starting the rotation again
+    $DF Dynamic Rotation: false
     // If enabled a private message with player statistics is sent after each round.
     //$DF Send Player Stats Message: true
     // Send a chat message to players when they join the server ($PLAYER is replaced by player name)

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ Configuration example:
     $DF Player Damage Modifier: 1.0
     // Enable '/save' and '/load' chat commands (works for all clients) and quick save/load controls handling (works for Dash Faction 1.5.0+ clients). Option designed with run-maps in mind.
     $DF Saving Enabled: false
+    // Randomize the order of levels in the server rotation (instead of loading them sequentially)
+    $DF Randomize Rotation: false
     // Enable Universal Plug-and-Play (enabled by default)
     $DF UPnP Enabled: true
     // Force all players to use the same character (check pc_multi.tbl for valid names)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Configuration example:
     $DF Vote Restart: true
     // Enable vote next
     $DF Vote Next: true
+    // Enable vote random
+    $DF Vote Random: true
     // Enable vote previous
     $DF Vote Previous: true
     // Duration of player invulnerability after respawn in ms (default is the same as in stock RF - 1500)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Name                     | Description
 `map_next`               | load next level
 `map_rand`               | load random level from rotation
 `map_prev`               | load previous level
+`shuffle_maps`           | shuffle the order of upcoming levels
 `kill_limit value`       | set kill limit
 `time_limit value`       | set time limit
 `geomod_limit value`     | set geomod limit
@@ -187,7 +188,7 @@ Configuration example:
     $DF Player Damage Modifier: 1.0
     // Enable '/save' and '/load' chat commands (works for all clients) and quick save/load controls handling (works for Dash Faction 1.5.0+ clients). Option designed with run-maps in mind.
     $DF Saving Enabled: false
-    // Randomize the order of levels in the server rotation (instead of loading them sequentially)
+    // Instead of loading levels in order, load a random level from the rotation after each round (only applies when round ends due to kill, cap, or time limit)
     $DF Random Level Order: false
     // Enable Universal Plug-and-Play (enabled by default)
     $DF UPnP Enabled: true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,7 @@ Version 1.9.0 (not released yet)
 - Add Kill Reward settings for dedicated servers
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
+- Add `map_rand` command and `vote rand` - both initiate a level change to a random level on the rotation
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,8 +44,7 @@ Version 1.9.0 (not released yet)
 - Add level filename to "Level Initializing" console message
 - Add `map_rand` command to change to a random level on the rotation
 - Add `vote rand` vote type to initiate a level change to a random level on the rotation
-- Add `$DF Random Level Order` option in dedicated server config
-- Add `$DF Dynamic Rotation` option in dedicated server config (shuffles rotation once complete)
+- Add `$DF Dynamic Rotation` option in dedicated server config
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
 
 Version 1.8.0 (released 2022-09-17)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,7 @@ Version 1.9.0 (not released yet)
 - Add `map_rand` command to change to a random level on the rotation
 - Add `vote rand` vote type to initiate a level change to a random level on the rotation
 - Add `$DF Random Level Order` option in dedicated server config
+- Add `$DF Dynamic Rotation` option in dedicated server config (shuffles rotation once complete)
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@ Version 1.9.0 (not released yet)
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
 - Add `map_rand` command and `vote rand` - both initiate a level change to a random level on the rotation
+- Add `$DF Randomize Rotation` option in dedicated server config
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,7 +42,9 @@ Version 1.9.0 (not released yet)
 - Add Kill Reward settings for dedicated servers
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
-- Add `map_rand` command and `vote rand` - both initiate a level change to a random level on the rotation
+- Add `shuffle_maps` command to shuffle the order of levels on the server's rotation
+- Add `map_rand` command to change to a random level on the rotation
+- Add `vote rand` vote type to initiate a level change to a random level on the rotation
 - Add `$DF Random Level Order` option in dedicated server config
 
 Version 1.8.0 (released 2022-09-17)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,7 +42,6 @@ Version 1.9.0 (not released yet)
 - Add Kill Reward settings for dedicated servers
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
-- Add `shuffle_maps` command to shuffle the order of levels on the server's rotation
 - Add `map_rand` command to change to a random level on the rotation
 - Add `vote rand` vote type to initiate a level change to a random level on the rotation
 - Add `$DF Random Level Order` option in dedicated server config

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,7 +43,7 @@ Version 1.9.0 (not released yet)
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
 - Add `map_rand` command and `vote rand` - both initiate a level change to a random level on the rotation
-- Add `$DF Randomize Rotation` option in dedicated server config
+- Add `$DF Random Level Order` option in dedicated server config
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -44,6 +44,15 @@
 GameConfig g_game_config;
 HMODULE g_hmodule;
 
+std::mt19937 g_rng;
+
+void initialize_random_generator()
+{
+    // seed rng with the current time
+    auto seed = std::chrono::steady_clock::now().time_since_epoch().count();
+    g_rng.seed(static_cast<unsigned long>(seed));
+}
+
 CallHook<void()> rf_init_hook{
     0x004B27CD,
     []() {
@@ -77,15 +86,6 @@ CodeInjection cleanup_game_hook{
         debug_cleanup();
     },
 };
-
-std::mt19937 rng;
-
-void initialize_random_generator()
-{
-    // seed rng with the current time
-    auto seed = std::chrono::steady_clock::now().time_since_epoch().count();
-    rng.seed(static_cast<unsigned long>(seed));
-}
 
 static void maybe_autosave()
 {

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -79,7 +79,6 @@ CodeInjection cleanup_game_hook{
 };
 
 std::mt19937 rng;
-std::uniform_int_distribution<std::size_t> dist;
 
 void initialize_random_generator()
 {

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -78,6 +78,16 @@ CodeInjection cleanup_game_hook{
     },
 };
 
+std::mt19937 rng;
+std::uniform_int_distribution<std::size_t> dist;
+
+void initialize_random_generator()
+{
+    // seed rng with the current time
+    auto seed = std::chrono::steady_clock::now().time_since_epoch().count();
+    rng.seed(static_cast<unsigned long>(seed));
+}
+
 static void maybe_autosave()
 {
     static int pending_autosave = 0;
@@ -337,6 +347,9 @@ extern "C" DWORD __declspec(dllexport) Init([[maybe_unused]] void* unused)
     // Init logging and crash dump support first
     init_logging();
     init_crash_handler();
+
+    // Init random number generator
+    initialize_random_generator();
 
     // Enable Data Execution Prevention
     if (!SetProcessDEPPolicy(PROCESS_DEP_ENABLE))

--- a/game_patch/main/main.h
+++ b/game_patch/main/main.h
@@ -6,7 +6,6 @@ extern GameConfig g_game_config;
 
 // random number generator
 extern std::mt19937 rng;
-extern std::uniform_int_distribution<std::size_t> dist;
 void initialize_random_generator();
 
 #ifdef _WINDOWS_

--- a/game_patch/main/main.h
+++ b/game_patch/main/main.h
@@ -1,8 +1,14 @@
 #pragma once
-
+#include <random>
 #include <common/config/GameConfig.h>
 
 extern GameConfig g_game_config;
+
+// random number generator
+extern std::mt19937 rng;
+extern std::uniform_int_distribution<std::size_t> dist;
+void initialize_random_generator();
+
 #ifdef _WINDOWS_
 extern HMODULE g_hmodule;
 #endif

--- a/game_patch/main/main.h
+++ b/game_patch/main/main.h
@@ -5,7 +5,7 @@
 extern GameConfig g_game_config;
 
 // random number generator
-extern std::mt19937 rng;
+extern std::mt19937 g_rng;
 void initialize_random_generator();
 
 #ifdef _WINDOWS_

--- a/game_patch/multi/commands.cpp
+++ b/game_patch/multi/commands.cpp
@@ -102,6 +102,17 @@ ConsoleCommand2 map_next_cmd{
     "Load next level",
 };
 
+ConsoleCommand2 shuffle_level_list_cmd{
+    "shuffle_maps",
+    []() {
+        if (validate_is_server() && validate_not_limbo()) {
+            rf::multi_chat_say("\xA6 Shuffling level order", false);
+            shuffle_level_array();
+        }
+    },
+    "Shuffle the order of upcoming levels",
+};
+
 ConsoleCommand2 map_rand_cmd{
     "map_rand",
     []() {
@@ -211,6 +222,7 @@ void init_server_commands()
     map_rest_cmd.register_cmd();
     map_next_cmd.register_cmd();
     map_rand_cmd.register_cmd();
+    shuffle_level_list_cmd.register_cmd();
     map_prev_cmd.register_cmd();
 
     AsmWriter(0x0047B6F0).jmp(ban_cmd_handler_hook);

--- a/game_patch/multi/commands.cpp
+++ b/game_patch/multi/commands.cpp
@@ -48,11 +48,11 @@ void load_rand_level()
 {
     std::srand(static_cast<unsigned int>(std::time(nullptr)));
     // select a random level index from the rotation, excluding the currently loaded level
-    int rand_level_index;
+    int rand_level_index = rf::netgame.current_level_index;
     int num_levels = rf::netgame.levels.size();
     do {
-        rand_level_index = std::rand() % num_levels;
-    } while (rand_level_index == rf::netgame.current_level_index);
+    rand_level_index = std::rand() % num_levels;
+    } while (rand_level_index == rf::netgame.current_level_index && rf::netgame.levels.size() > 1); // prevent infinite loop if rotation has only 1 map
     rf::netgame.current_level_index = rand_level_index;
     rf::multi_change_level(rf::netgame.levels[rf::netgame.current_level_index]);
 }

--- a/game_patch/multi/commands.cpp
+++ b/game_patch/multi/commands.cpp
@@ -5,11 +5,10 @@
 #include "../rf/level.h"
 #include "../rf/player/player.h"
 #include "../rf/crt.h"
+#include "server.h"
 #include "multi.h"
 #include <patch_common/AsmWriter.h>
 #include <patch_common/CallHook.h>
-#include <cstdlib>
-#include <ctime>
 #include <vector>
 
 std::vector<int> g_players_to_kick;
@@ -46,15 +45,7 @@ void load_prev_level()
 
 void load_rand_level()
 {
-    std::srand(static_cast<unsigned int>(std::time(nullptr)));
-    // select a random level index from the rotation, excluding the currently loaded level
-    int rand_level_index = rf::netgame.current_level_index;
-    int num_levels = rf::netgame.levels.size();
-    do {
-    rand_level_index = std::rand() % num_levels;
-    } while (rand_level_index == rf::netgame.current_level_index && rf::netgame.levels.size() > 1); // prevent infinite loop if rotation has only 1 map
-    rf::netgame.current_level_index = rand_level_index;
-    rf::multi_change_level(rf::netgame.levels[rf::netgame.current_level_index]);
+    rf::multi_change_level(get_rand_level_filename());
 }
 
 bool validate_is_server()

--- a/game_patch/multi/commands.cpp
+++ b/game_patch/multi/commands.cpp
@@ -102,17 +102,6 @@ ConsoleCommand2 map_next_cmd{
     "Load next level",
 };
 
-ConsoleCommand2 shuffle_level_list_cmd{
-    "shuffle_maps",
-    []() {
-        if (validate_is_server() && validate_not_limbo()) {
-            rf::multi_chat_say("\xA6 Shuffling level order", false);
-            shuffle_level_array();
-        }
-    },
-    "Shuffle the order of upcoming levels",
-};
-
 ConsoleCommand2 map_rand_cmd{
     "map_rand",
     []() {
@@ -222,7 +211,6 @@ void init_server_commands()
     map_rest_cmd.register_cmd();
     map_next_cmd.register_cmd();
     map_rand_cmd.register_cmd();
-    shuffle_level_list_cmd.register_cmd();
     map_prev_cmd.register_cmd();
 
     AsmWriter(0x0047B6F0).jmp(ban_cmd_handler_hook);

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -318,28 +318,28 @@ static void send_private_message_with_stats(rf::Player* player)
 
 void shuffle_level_array()
 {
-    std::shuffle(rf::netgame.levels.begin(), rf::netgame.levels.end(), rng);
+    std::ranges::shuffle(rf::netgame.levels, rng);
     xlog::info("Shuffled level rotation");
 }
 
 const char* get_rand_level_filename()
 {
-    int num_levels = rf::netgame.levels.size();
+    std::size_t num_levels = rf::netgame.levels.size();
 
-    if (num_levels > 1) {
-        std::uniform_int_distribution<int> dist(0, num_levels - 2);
-        int rand_level_index = dist(rng);
-
-        // avoid selecting the current level
-        if (rand_level_index >= rf::netgame.current_level_index) {
-            rand_level_index++;
-        }
-
-        return rf::netgame.levels[rand_level_index].c_str();
+    if (num_levels <= 1) {
+        // nowhere else to go, we're staying here!
+        return rf::netgame.levels[rf::netgame.current_level_index].c_str();
     }
 
-    // nowhere else to go, we're staying here!
-    return rf::netgame.levels[rf::netgame.current_level_index].c_str();
+    std::uniform_int_distribution<std::size_t> dist(0, num_levels - 2);
+    std::size_t rand_level_index = dist(rng);
+
+    // Avoid selecting the current level
+    if (rand_level_index >= rf::netgame.current_level_index) {
+        rand_level_index++;
+    }
+
+    return rf::netgame.levels[rand_level_index].c_str();
 }
 
 bool handle_server_chat_command(std::string_view server_command, rf::Player* sender)

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -37,6 +37,7 @@ const char* g_rcon_cmd_whitelist[] = {
     "map_ext",
     "map_rest",
     "map_next",
+    "map_rand",
     "map_prev",
 };
 

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -324,10 +324,10 @@ void shuffle_level_array()
 
 const char* get_rand_level_filename()
 {
-    std::size_t num_levels = rf::netgame.levels.size();
+    const std::size_t num_levels = rf::netgame.levels.size();
 
-    // current_level_index keeps our position in rotation while we go somewhere else
-    rf::String& filename = rf::level_filename_to_load;
+    // store current level filename
+    rf::String filename = rf::level_filename_to_load;
 
     if (num_levels <= 1) {
         // nowhere else to go, we're staying here!
@@ -337,7 +337,7 @@ const char* get_rand_level_filename()
     std::uniform_int_distribution<std::size_t> dist_levels(0, num_levels - 1);
     std::size_t rand_level_index = dist_levels(rng);
 
-    // avoid selecting current level
+    // avoid selecting current level filename (unless it appears more than once on map list)
     if (rf::netgame.levels[rand_level_index] == filename) {
         rand_level_index = (rand_level_index + 1) % num_levels;
     }

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -326,9 +326,9 @@ const char* get_rand_level_filename()
     int num_levels = rf::netgame.levels.size();
     do {
         rand_level_index = std::rand() % num_levels;
-    } while (rand_level_index == rf::netgame.current_level_index && rf::netgame.levels.size() > 1); // prevent infinite loop if rotation has only 1 map
-    rf::netgame.current_level_index = rand_level_index;
-    return rf::netgame.levels[rf::netgame.current_level_index];
+    } while (rand_level_index == rf::netgame.current_level_index && rf::netgame.levels.size() > 1);
+    // prevent infinite loop if rotation has only 1 map
+    return rf::netgame.levels[rand_level_index];
 }
 
 bool handle_server_chat_command(std::string_view server_command, rf::Player* sender)

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -337,9 +337,9 @@ const char* get_rand_level_filename()
     std::uniform_int_distribution<std::size_t> dist_levels(0, num_levels - 1);
     std::size_t rand_level_index = dist_levels(rng);
 
-    // keep rolling until we get something that's not the current level
-    while (rf::netgame.levels[rand_level_index] == filename) {
-        rand_level_index = dist_levels(rng);
+    // avoid selecting current level
+    if (rf::netgame.levels[rand_level_index] == filename) {
+        rand_level_index = (rand_level_index + 1) % num_levels;
     }
 
     filename = rf::netgame.levels[rand_level_index];

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -327,7 +327,7 @@ const char* get_rand_level_filename()
     std::size_t num_levels = rf::netgame.levels.size();
 
     // current_level_index keeps our position in rotation while we go somewhere else
-    rf::String filename = rf::level_filename_to_load;
+    const rf::String& filename = rf::level_filename_to_load;
 
     if (num_levels <= 1) {
         // nowhere else to go, we're staying here!

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -327,7 +327,7 @@ const char* get_rand_level_filename()
     std::size_t num_levels = rf::netgame.levels.size();
 
     // current_level_index keeps our position in rotation while we go somewhere else
-    const rf::String& filename = rf::level_filename_to_load;
+    rf::String& filename = rf::level_filename_to_load;
 
     if (num_levels <= 1) {
         // nowhere else to go, we're staying here!

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -318,11 +318,7 @@ static void send_private_message_with_stats(rf::Player* player)
 
 void shuffle_level_array()
 {
-    std::size_t n = rf::netgame.levels.size();
-    for (std::size_t i = n - 1; i > 0; --i) {
-        std::size_t j = dist(rng) % (i + 1);
-        std::swap(rf::netgame.levels[i], rf::netgame.levels[j]);
-    }
+    std::shuffle(rf::netgame.levels.begin(), rf::netgame.levels.end(), rng);
     xlog::info("Shuffled level rotation");
 }
 

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -39,7 +39,6 @@ const char* g_rcon_cmd_whitelist[] = {
     "map_next",
     "map_rand",
     "map_prev",
-    "shuffle_maps",
 };
 
 ServerAdditionalConfig g_additional_server_config;

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -312,7 +312,10 @@ static void send_private_message_with_stats(rf::Player* player)
 
 void shuffle_level_array()
 {
-    for (std::size_t i = rf::netgame.levels.size() - 1; i > 0; --i) {std::swap(rf::netgame.levels[i], rf::netgame.levels[std::rand() % (i + 1)]);
+    std::size_t n = rf::netgame.levels.size();
+    for (std::size_t i = n - 1; i > 0; --i) {
+        std::size_t j = std::rand() % (i + 1);
+        std::swap(rf::netgame.levels[i], rf::netgame.levels[j]);
     }
 }
 

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -318,7 +318,7 @@ static void send_private_message_with_stats(rf::Player* player)
 
 void shuffle_level_array()
 {
-    std::ranges::shuffle(rf::netgame.levels, rng);
+    std::ranges::shuffle(rf::netgame.levels, g_rng);
     xlog::warn("Shuffled level rotation");
 }
 
@@ -332,7 +332,7 @@ const char* get_rand_level_filename()
     }
 
     std::uniform_int_distribution<std::size_t> dist_levels(0, num_levels - 1);
-    std::size_t rand_level_index = dist_levels(rng);
+    std::size_t rand_level_index = dist_levels(g_rng);
 
     // avoid selecting current level filename (unless it appears more than once on map list)
     if (rf::netgame.levels[rand_level_index] == rf::level_filename_to_load) {

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -39,6 +39,7 @@ const char* g_rcon_cmd_whitelist[] = {
     "map_next",
     "map_rand",
     "map_prev",
+    "shuffle_maps",
 };
 
 ServerAdditionalConfig g_additional_server_config;
@@ -309,6 +310,11 @@ static void send_private_message_with_stats(rf::Player* player)
     send_chat_line_packet(str.c_str(), player);
 }
 
+void shuffle_level_array()
+{
+    for (std::size_t i = rf::netgame.levels.size() - 1; i > 0; --i) {std::swap(rf::netgame.levels[i], rf::netgame.levels[std::rand() % (i + 1)]);
+    }
+}
 
 const char* get_rand_level_filename()
 {
@@ -680,7 +686,8 @@ CallHook<void(const char* filename)> multi_change_level_call_hook{
     0x0046E89C,
     [](const char* filename){
         multi_change_level_call_hook.call_target(g_additional_server_config.randomize_rotation ? get_rand_level_filename() : filename);
-    }};
+    }
+};
 
 void server_init()
 {

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -71,6 +71,7 @@ void load_additional_server_config(rf::Parser& parser)
     parse_vote_config("Vote Extend", g_additional_server_config.vote_extend, parser);
     parse_vote_config("Vote Restart", g_additional_server_config.vote_restart, parser);
     parse_vote_config("Vote Next", g_additional_server_config.vote_next, parser);
+    parse_vote_config("Vote Random", g_additional_server_config.vote_rand, parser);
     parse_vote_config("Vote Previous", g_additional_server_config.vote_previous, parser);
     if (parser.parse_optional("$DF Spawn Protection Duration:")) {
         g_additional_server_config.spawn_protection_duration_ms = parser.parse_uint();

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -165,16 +165,16 @@ void load_additional_server_config(rf::Parser& parser)
         }
     }
 
-    if (parser.parse_optional("$DF Send Player Stats Message:")) {
-        g_additional_server_config.stats_message_enabled = parser.parse_bool();
-    }
-
     if (parser.parse_optional("$DF Random Level Order:")) {
         g_additional_server_config.randomize_rotation = parser.parse_bool();
     }
 
     if (parser.parse_optional("$DF Dynamic Rotation:")) {
         g_additional_server_config.dynamic_rotation = parser.parse_bool();
+    }
+
+    if (parser.parse_optional("$DF Send Player Stats Message:")) {
+        g_additional_server_config.stats_message_enabled = parser.parse_bool();
     }
 
     if (parser.parse_optional("$DF Welcome Message:")) {

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -326,25 +326,20 @@ const char* get_rand_level_filename()
 {
     const std::size_t num_levels = rf::netgame.levels.size();
 
-    // store current level filename
-    rf::String filename = rf::level_filename_to_load;
-
     if (num_levels <= 1) {
         // nowhere else to go, we're staying here!
-        return filename.c_str();
+        return rf::level_filename_to_load.c_str();
     }
 
     std::uniform_int_distribution<std::size_t> dist_levels(0, num_levels - 1);
     std::size_t rand_level_index = dist_levels(rng);
 
     // avoid selecting current level filename (unless it appears more than once on map list)
-    if (rf::netgame.levels[rand_level_index] == filename) {
+    if (rf::netgame.levels[rand_level_index] == rf::level_filename_to_load) {
         rand_level_index = (rand_level_index + 1) % num_levels;
     }
 
-    filename = rf::netgame.levels[rand_level_index];
-
-    return filename.c_str();
+    return rf::netgame.levels[rand_level_index].c_str();
 }
 
 bool handle_server_chat_command(std::string_view server_command, rf::Player* sender)

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -327,29 +327,24 @@ const char* get_rand_level_filename()
     std::size_t num_levels = rf::netgame.levels.size();
 
     // current_level_index keeps our position in rotation while we go somewhere else
-    const char* current_level_filename = rf::level_filename_to_load;
-
-    xlog::debug("Starting random selection process, current level is {}", current_level_filename);
+    rf::String filename = rf::level_filename_to_load;
 
     if (num_levels <= 1) {
         // nowhere else to go, we're staying here!
-        xlog::debug("Map list has only 1 member, reloading current level {}", current_level_filename);
-        return current_level_filename;
+        return filename.c_str();
     }
 
     std::uniform_int_distribution<std::size_t> dist_levels(0, num_levels - 1);
     std::size_t rand_level_index = dist_levels(rng);
 
     // keep rolling until we get something that's not the current level
-    while (rf::netgame.levels[rand_level_index] == current_level_filename) {
+    while (rf::netgame.levels[rand_level_index] == filename) {
         rand_level_index = dist_levels(rng);
     }
 
-    const char* selected_level_filename = rf::netgame.levels[rand_level_index];
+    filename = rf::netgame.levels[rand_level_index];
 
-    xlog::debug("Loading randomly selected level {}", selected_level_filename);
-
-    return selected_level_filename;
+    return filename.c_str();
 }
 
 bool handle_server_chat_command(std::string_view server_command, rf::Player* sender)

--- a/game_patch/multi/server.h
+++ b/game_patch/multi/server.h
@@ -12,3 +12,4 @@ bool check_server_chat_command(const char* msg, rf::Player* sender);
 bool server_is_saving_enabled();
 void server_reliable_socket_ready(rf::Player* player);
 bool server_weapon_items_give_full_ammo();
+const char* get_rand_level_filename();

--- a/game_patch/multi/server.h
+++ b/game_patch/multi/server.h
@@ -13,3 +13,4 @@ bool server_is_saving_enabled();
 void server_reliable_socket_ready(rf::Player* player);
 bool server_weapon_items_give_full_ammo();
 const char* get_rand_level_filename();
+void shuffle_level_array();

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -33,6 +33,7 @@ struct ServerAdditionalConfig
     VoteConfig vote_extend;
     VoteConfig vote_restart;
     VoteConfig vote_next;
+    VoteConfig vote_rand;
     VoteConfig vote_previous;
     int spawn_protection_duration_ms = 1500;
     std::optional<float> spawn_life;
@@ -68,6 +69,7 @@ void init_server_commands();
 void extend_round_time(int minutes);
 void restart_current_level();
 void load_next_level();
+void load_rand_level();
 void load_prev_level();
 void server_vote_on_limbo_state_enter();
 void process_delayed_kicks();

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -51,6 +51,7 @@ struct ServerAdditionalConfig
     int anticheat_level = 0;
     bool stats_message_enabled = true;
     bool randomize_rotation = false;
+    bool dynamic_rotation = false;
     std::string welcome_message;
     bool weapon_items_give_full_ammo = false;
     float kill_reward_health = 0.0f;

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -50,6 +50,7 @@ struct ServerAdditionalConfig
     std::optional<float> max_fov;
     int anticheat_level = 0;
     bool stats_message_enabled = true;
+    bool randomize_rotation = false;
     std::string welcome_message;
     bool weapon_items_give_full_ammo = false;
     float kill_reward_health = 0.0f;

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -50,7 +50,6 @@ struct ServerAdditionalConfig
     std::optional<float> max_fov;
     int anticheat_level = 0;
     bool stats_message_enabled = true;
-    bool randomize_rotation = false;
     bool dynamic_rotation = false;
     std::string welcome_message;
     bool weapon_items_give_full_ammo = false;

--- a/game_patch/multi/votes.cpp
+++ b/game_patch/multi/votes.cpp
@@ -322,6 +322,30 @@ struct VoteNext : public Vote
     }
 };
 
+struct VoteRandom : public Vote
+{
+    [[nodiscard]] std::string get_title() const override
+    {
+        return "LOAD RANDOM LEVEL";
+    }
+
+    void on_accepted() override
+    {
+        send_chat_line_packet("\xA6 Vote passed: loading random level from rotation", nullptr);
+        load_rand_level();
+    }
+
+    [[nodiscard]] bool is_allowed_in_limbo_state() const override
+    {
+        return false;
+    }
+
+    [[nodiscard]] const VoteConfig& get_config() const override
+    {
+        return g_additional_server_config.vote_rand;
+    }
+};
+
 struct VotePrevious : public Vote
 {
     [[nodiscard]] std::string get_title() const override
@@ -448,6 +472,8 @@ void handle_vote_command(std::string_view vote_name, std::string_view vote_arg, 
         g_vote_mgr.StartVote<VoteRestart>(vote_arg, sender);
     else if (vote_name == "next")
         g_vote_mgr.StartVote<VoteNext>(vote_arg, sender);
+    else if (vote_name == "rand")
+        g_vote_mgr.StartVote<VoteRandom>(vote_arg, sender);
     else if (vote_name == "previous" || vote_name == "prev")
         g_vote_mgr.StartVote<VotePrevious>(vote_arg, sender);
     else if (vote_name == "yes" || vote_name == "y")

--- a/game_patch/multi/votes.cpp
+++ b/game_patch/multi/votes.cpp
@@ -472,7 +472,7 @@ void handle_vote_command(std::string_view vote_name, std::string_view vote_arg, 
         g_vote_mgr.StartVote<VoteRestart>(vote_arg, sender);
     else if (vote_name == "next")
         g_vote_mgr.StartVote<VoteNext>(vote_arg, sender);
-    else if (vote_name == "rand")
+    else if (vote_name == "random" || vote_name == "rand")
         g_vote_mgr.StartVote<VoteRandom>(vote_arg, sender);
     else if (vote_name == "previous" || vote_name == "prev")
         g_vote_mgr.StartVote<VotePrevious>(vote_arg, sender);


### PR DESCRIPTION
This PR adds 3 features:
1. "map_rand": Console command, accessible to both server operators and rcon holders. When entered, switches to a map randomly selected from the server's rotation (excluding the currently loaded map).
2. "vote rand": Vote option in multiplayer games (controlled with "$DF Vote Random" in dedicated_server.txt, defaults false). Upon successful vote, switches to a map randomly selected from the server's rotation (excluding the currently loaded map).
3. "$DF Randomize Rotation": Configurable option in dedicated_server.txt (defaults to false). If true, when a game ends because time/frag/cap limit has been met, the next map is randomly selected from the server's rotation (excluding the currently loaded map), as opposed to the default behaviour of loading the next map sequentially from the rotation. If false, default behaviour is maintained. This option does _not_ affect map changes issued by the "level", "map_next", "map_prev", or "map_rest" commands.

Resolves #52