### PR TITLE
Add player count to scoreboard

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@ Version 1.9.0 (not released yet)
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
+- Add current server player count to scoreboard
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/hud/multi_scoreboard.cpp
+++ b/game_patch/hud/multi_scoreboard.cpp
@@ -52,14 +52,17 @@ int draw_scoreboard_header(int x, int y, int w, rf::NetGameType game_type, bool 
 
     // Draw Game Type name
     if (!dry_run) {
-        const char* game_type_name;
-        if (game_type == rf::NG_TYPE_DM)
-            game_type_name = rf::strings::deathmatch;
-        else if (game_type == rf::NG_TYPE_CTF)
-            game_type_name = rf::strings::capture_the_flag;
-        else
-            game_type_name = rf::strings::team_deathmatch;
-        rf::gr::string_aligned(rf::gr::ALIGN_CENTER, x_center, cur_y, game_type_name);
+        int num_players = rf::multi_num_players();
+        std::string player_count_str =
+            " WITH " + std::to_string(num_players) + (num_players > 1 ? " PLAYERS" : " PLAYER");
+
+        std::string game_type_name = (game_type == rf::NG_TYPE_DM)    ? rf::strings::deathmatch
+                                     : (game_type == rf::NG_TYPE_CTF) ? rf::strings::capture_the_flag
+                                                                      : rf::strings::team_deathmatch;
+
+        game_type_name += player_count_str;
+
+        rf::gr::string_aligned(rf::gr::ALIGN_CENTER, x_center, cur_y, game_type_name.c_str());
     }
     int font_h = rf::gr::get_font_height(-1);
     cur_y += font_h + 8;

--- a/game_patch/hud/multi_scoreboard.cpp
+++ b/game_patch/hud/multi_scoreboard.cpp
@@ -55,7 +55,7 @@ int draw_scoreboard_header(int x, int y, int w, rf::NetGameType game_type, bool 
     if (!dry_run) {
         int num_players = rf::multi_num_players();
         std::string player_count_str =
-            " WITH " + std::to_string(num_players) + (num_players > 1 ? " PLAYERS" : " PLAYER");
+            " | " + std::to_string(num_players) + (num_players > 1 ? " PLAYERS" : " PLAYER");
 
         std::string game_type_name = (game_type == rf::NG_TYPE_DM)    ? rf::strings::deathmatch
                                      : (game_type == rf::NG_TYPE_CTF) ? rf::strings::capture_the_flag


### PR DESCRIPTION
Adds the current server player count to the scoreboard for all gamemodes as shown in the screenshots below.

Resolves #27

![20240916_160417_dm-factory5](https://github.com/user-attachments/assets/2a143497-5fe1-4a07-a243-48f6a7940cb9)
![20240916_160438_dmgbrffta04](https://github.com/user-attachments/assets/a058bc11-9228-4567-add1-a51d797f17a7)
![20240916_160429_ctf-dualityalm](https://github.com/user-attachments/assets/e1a9df4f-1504-48ef-b91f-b2f10cde886b)