### PR TITLE
Allow server operators to exempt some weapons from weapon stay

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,14 +164,20 @@ Configuration example:
         +Rate Limit: 10
     // If Weapon Stay is on, set some specific weapon pickups to be exempt (act as if it were not on) for balancing
     $DF Weapon Stay Exemptions: false
-        +Rocket Launcher: false
-        +Heavy Machine Gun: false
+        +Flamethrower: false
+        +Control Baton: false
+        +Riot Shield: false
+        +Pistol: false
+        +Shotgun: false
+        +Submachine Gun: false
         +Sniper Rifle: false
         +Assault Rifle: false
-        +Submachine Gun: false
-        +Shotgun: false
+        +Heavy Machine Gun: false
         +Precision Rifle: false
         +Rail Driver: false
+        +Rocket Launcher: false
+        +Grenade: false
+        +Remote Charges: false
     // Replace all "Shotgun" items with "rail gun" items when loading RFLs
     $DF Item Replacement: "Shotgun" "rail gun"
     // If enabled players are given full ammo when picking up weapon items, can be useful with the Weapons Stay standard option

--- a/README.md
+++ b/README.md
@@ -162,6 +162,16 @@ Configuration example:
         +Sound ID: 29
         // max sound packets per second - keep it low to save bandwidth
         +Rate Limit: 10
+    // If Weapon Stay is on, set some specific weapon pickups to be exempt (act as if it were not on) for balancing
+    $DF Weapon Stay Exemptions: false
+        +Rocket Launcher: false
+        +Heavy Machine Gun: false
+        +Sniper Rifle: false
+        +Assault Rifle: false
+        +Submachine Gun: false
+        +Shotgun: false
+        +Precision Rifle: false
+        +Rail Driver: false
     // Replace all "Shotgun" items with "rail gun" items when loading RFLs
     $DF Item Replacement: "Shotgun" "rail gun"
     // If enabled players are given full ammo when picking up weapon items, can be useful with the Weapons Stay standard option

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@ Version 1.9.0 (not released yet)
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
+- Add `$DF Weapon Stay Exemptions` option in dedicated server config
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -96,6 +96,34 @@ void load_additional_server_config(rf::Parser& parser)
         }
     }
 
+    if (parser.parse_optional("$DF Weapon Stay Exemptions:")) {
+        g_additional_server_config.weapon_stay_exemptions.enabled = parser.parse_bool();
+        if (parser.parse_optional("+Rocket Launcher:")) {
+            g_additional_server_config.weapon_stay_exemptions.rocket_launcher = parser.parse_bool();
+        }
+        if (parser.parse_optional("+Heavy Machine Gun:")) {
+            g_additional_server_config.weapon_stay_exemptions.heavy_machine_gun = parser.parse_bool();
+        }
+        if (parser.parse_optional("+Sniper Rifle:")) {
+            g_additional_server_config.weapon_stay_exemptions.sniper_rifle = parser.parse_bool();
+        }
+        if (parser.parse_optional("+Assault Rifle:")) {
+            g_additional_server_config.weapon_stay_exemptions.assault_rifle = parser.parse_bool();
+        }
+        if (parser.parse_optional("+Submachine Gun:")) {
+            g_additional_server_config.weapon_stay_exemptions.machine_pistol = parser.parse_bool();
+        }
+        if (parser.parse_optional("+Shotgun:")) {
+            g_additional_server_config.weapon_stay_exemptions.shotgun = parser.parse_bool();
+        }
+        if (parser.parse_optional("+Precision Rifle:")) {
+            g_additional_server_config.weapon_stay_exemptions.scope_assault_rifle = parser.parse_bool();
+        }
+        if (parser.parse_optional("+Rail Driver:")) {
+            g_additional_server_config.weapon_stay_exemptions.rail_gun = parser.parse_bool();
+        }
+    }
+
     while (parser.parse_optional("$DF Item Replacement:")) {
         rf::String old_item;
         rf::String new_item;
@@ -659,6 +687,79 @@ CodeInjection multi_limbo_init_injection{
     },
 };
 
+// memory addresses for weapon stay exemption indexes
+constexpr std::pair<bool WeaponStayExemptionConfig::*, uintptr_t> weapon_exemptions[] = {
+    {&WeaponStayExemptionConfig::rocket_launcher, 0x00872458},
+    {&WeaponStayExemptionConfig::heavy_machine_gun, 0x00872460},
+    {&WeaponStayExemptionConfig::sniper_rifle, 0x00872440},
+    {&WeaponStayExemptionConfig::assault_rifle, 0x00872470},
+    {&WeaponStayExemptionConfig::machine_pistol, 0x0085CCD8},
+    {&WeaponStayExemptionConfig::shotgun, 0x00872108},
+    {&WeaponStayExemptionConfig::scope_assault_rifle, 0x0087245C},
+    {&WeaponStayExemptionConfig::rail_gun, 0x00872124}
+};
+
+// declare optional vector for weapon stay exemptions
+std::optional<std::vector<uintptr_t>> weapon_stay_exempt_indexes;
+
+// Consolidate weapon stay exemption logic for both injections
+void handle_weapon_stay_exemption(BaseCodeInjection::Regs& regs, uintptr_t jump_address)
+{
+    if (!weapon_stay_exempt_indexes) {
+        return; // no exemptions if the optional vector is not populated
+    }
+    for (const auto& index_addr : *weapon_stay_exempt_indexes) {
+        int weapon_index = *reinterpret_cast<int*>(index_addr);
+        if (regs.eax == weapon_index) {
+            regs.eip = jump_address;
+            return;
+        }
+    }
+}
+
+// Weapon stay exemption part 1: remove item when it is picked up and start respawn timer
+CodeInjection weapon_stay_remove_instance_injection{
+    0x0045982E, [](BaseCodeInjection::Regs& regs) { handle_weapon_stay_exemption(regs, 0x00459865); }};
+
+// Weapon stay exemption part 2: allow picking up item by a player who already did (after it respawns)
+CodeInjection weapon_stay_allow_pickup_injection{
+    0x004596B4, [](BaseCodeInjection::Regs& regs) { handle_weapon_stay_exemption(regs, 0x004596CD); }};
+
+void initialize_weapon_stay_exemptions()
+{
+    const auto& config = g_additional_server_config.weapon_stay_exemptions;
+    if (!config.enabled) {
+        xlog::debug("Weapon stay exemptions are not enabled.");
+        return;
+    }
+
+    // Populate weapon stay exemption indexes
+    weapon_stay_exempt_indexes = std::vector<uintptr_t>{};
+    std::string exempted_weapons_log;
+
+    for (const auto& [config_member, index_addr] : weapon_exemptions) {
+        // Add debug logs to see which weapons are being checked
+        bool is_exempt = config.*config_member;
+        xlog::debug("Checking weapon at address: {}. Exempt: {}", index_addr, is_exempt);
+
+        if (is_exempt) {
+            weapon_stay_exempt_indexes->push_back(index_addr);
+            exempted_weapons_log += std::to_string(index_addr) + " "; // Log as decimal
+        }
+    }
+
+    if (!weapon_stay_exempt_indexes->empty()) {
+        xlog::debug("Injected weapon stay exemptions: {}", exempted_weapons_log);
+    }
+    else {
+        xlog::debug("No weapon exemptions applied.");
+    }
+
+    // injections
+    weapon_stay_remove_instance_injection.install();
+    weapon_stay_allow_pickup_injection.install();
+}
+
 void server_init()
 {
     // Override rcon command whitelist
@@ -724,6 +825,9 @@ void server_init()
 
     // Reduce limbo duration if server is empty
     multi_limbo_init_injection.install();
+
+    // Weapon stay exemptions
+    initialize_weapon_stay_exemptions();
 }
 
 void server_do_frame()

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -98,11 +98,23 @@ void load_additional_server_config(rf::Parser& parser)
 
     if (parser.parse_optional("$DF Weapon Stay Exemptions:")) {
         g_additional_server_config.weapon_stay_exemptions.enabled = parser.parse_bool();
-        if (parser.parse_optional("+Rocket Launcher:")) {
-            g_additional_server_config.weapon_stay_exemptions.rocket_launcher = parser.parse_bool();
+        if (parser.parse_optional("+Flamethrower:")) {
+            g_additional_server_config.weapon_stay_exemptions.flamethrower = parser.parse_bool();
         }
-        if (parser.parse_optional("+Heavy Machine Gun:")) {
-            g_additional_server_config.weapon_stay_exemptions.heavy_machine_gun = parser.parse_bool();
+        if (parser.parse_optional("+Control Baton:")) {
+            g_additional_server_config.weapon_stay_exemptions.riot_stick = parser.parse_bool();
+        }
+        if (parser.parse_optional("+Riot Shield:")) {
+            g_additional_server_config.weapon_stay_exemptions.riot_shield = parser.parse_bool();
+        }
+        if (parser.parse_optional("+Pistol:")) {
+            g_additional_server_config.weapon_stay_exemptions.handgun = parser.parse_bool();
+        }
+        if (parser.parse_optional("+Shotgun:")) {
+            g_additional_server_config.weapon_stay_exemptions.shotgun = parser.parse_bool();
+        }
+        if (parser.parse_optional("+Submachine Gun:")) {
+            g_additional_server_config.weapon_stay_exemptions.machine_pistol = parser.parse_bool();
         }
         if (parser.parse_optional("+Sniper Rifle:")) {
             g_additional_server_config.weapon_stay_exemptions.sniper_rifle = parser.parse_bool();
@@ -110,17 +122,23 @@ void load_additional_server_config(rf::Parser& parser)
         if (parser.parse_optional("+Assault Rifle:")) {
             g_additional_server_config.weapon_stay_exemptions.assault_rifle = parser.parse_bool();
         }
-        if (parser.parse_optional("+Submachine Gun:")) {
-            g_additional_server_config.weapon_stay_exemptions.machine_pistol = parser.parse_bool();
-        }
-        if (parser.parse_optional("+Shotgun:")) {
-            g_additional_server_config.weapon_stay_exemptions.shotgun = parser.parse_bool();
+        if (parser.parse_optional("+Heavy Machine Gun:")) {
+            g_additional_server_config.weapon_stay_exemptions.heavy_machine_gun = parser.parse_bool();
         }
         if (parser.parse_optional("+Precision Rifle:")) {
             g_additional_server_config.weapon_stay_exemptions.scope_assault_rifle = parser.parse_bool();
         }
         if (parser.parse_optional("+Rail Driver:")) {
             g_additional_server_config.weapon_stay_exemptions.rail_gun = parser.parse_bool();
+        }
+        if (parser.parse_optional("+Rocket Launcher:")) {
+            g_additional_server_config.weapon_stay_exemptions.rocket_launcher = parser.parse_bool();
+        }
+        if (parser.parse_optional("+Grenade:")) {
+            g_additional_server_config.weapon_stay_exemptions.grenade = parser.parse_bool();
+        }
+        if (parser.parse_optional("+Remote Charges:")) {
+            g_additional_server_config.weapon_stay_exemptions.remote_charge = parser.parse_bool();
         }
     }
 
@@ -234,6 +252,12 @@ constexpr std::pair<bool WeaponStayExemptionConfig::*, uintptr_t> weapon_exempti
     {&WeaponStayExemptionConfig::machine_pistol, 0x0085CCD8},
     {&WeaponStayExemptionConfig::shotgun, 0x00872108},
     {&WeaponStayExemptionConfig::scope_assault_rifle, 0x0087245C},
+    {&WeaponStayExemptionConfig::grenade, 0x00872118},
+    {&WeaponStayExemptionConfig::remote_charge, 0x0087210C},
+    {&WeaponStayExemptionConfig::handgun, 0x00872114},
+    {&WeaponStayExemptionConfig::flamethrower, 0x0087243C},
+    {&WeaponStayExemptionConfig::riot_stick, 0x00872468},
+    {&WeaponStayExemptionConfig::riot_shield, 0x0085CCE4},
     {&WeaponStayExemptionConfig::rail_gun, 0x00872124}};
 
 // declare optional vector for weapon stay exemptions
@@ -266,7 +290,7 @@ void initialize_weapon_stay_exemptions()
 {
     const auto& config = g_additional_server_config.weapon_stay_exemptions;
     if (!config.enabled) {
-        xlog::warn("Weapon stay exemptions are not enabled.");
+        xlog::debug("Weapon stay exemptions are not enabled.");
         return;
     }
 
@@ -277,7 +301,7 @@ void initialize_weapon_stay_exemptions()
     for (const auto& [config_member, index_addr] : weapon_exemptions) {
         // Add debug logs to see which weapons are being checked
         bool is_exempt = config.*config_member;
-        xlog::warn("Checking weapon at address: {}. Exempt: {}", index_addr, is_exempt);
+        xlog::debug("Checking weapon at address: {}. Exempt: {}", index_addr, is_exempt);
 
         if (is_exempt) {
             weapon_stay_exempt_indexes->push_back(index_addr);
@@ -286,10 +310,10 @@ void initialize_weapon_stay_exemptions()
     }
 
     if (!weapon_stay_exempt_indexes->empty()) {
-        xlog::warn("Injected weapon stay exemptions: {}", exempted_weapons_log);
+        xlog::debug("Injected weapon stay exemptions: {}", exempted_weapons_log);
     }
     else {
-        xlog::warn("No weapon exemptions applied.");
+        xlog::debug("No weapon exemptions applied.");
     }
 
     // injections

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -294,26 +294,16 @@ void initialize_weapon_stay_exemptions()
         return;
     }
 
-    // Populate weapon stay exemption indexes
+    // Populate weapon stay exemption array
     weapon_stay_exempt_indexes = std::vector<uintptr_t>{};
-    std::string exempted_weapons_log;
-
     for (const auto& [config_member, index_addr] : weapon_exemptions) {
         // Add debug logs to see which weapons are being checked
         bool is_exempt = config.*config_member;
-        xlog::debug("Checking weapon at address: {}. Exempt: {}", index_addr, is_exempt);
+        xlog::debug("Checking weapon at address: {}. Is exempt? {}", index_addr, is_exempt);
 
         if (is_exempt) {
             weapon_stay_exempt_indexes->push_back(index_addr);
-            exempted_weapons_log += std::to_string(index_addr) + " "; // Log as decimal
         }
-    }
-
-    if (!weapon_stay_exempt_indexes->empty()) {
-        xlog::debug("Injected weapon stay exemptions: {}", exempted_weapons_log);
-    }
-    else {
-        xlog::debug("No weapon exemptions applied.");
     }
 
     // injections

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -36,6 +36,12 @@ struct WeaponStayExemptionConfig
     bool machine_pistol = false;
     bool shotgun = false;
     bool scope_assault_rifle = false;
+    bool grenade = false;
+    bool remote_charge = false;
+    bool handgun = false;
+    bool flamethrower = false;
+    bool riot_stick = false;
+    bool riot_shield = false;
     bool rail_gun = false;
 };
 

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -26,6 +26,19 @@ struct HitSoundsConfig
     int rate_limit = 10;
 };
 
+struct WeaponStayExemptionConfig
+{
+    bool enabled = false;
+    bool rocket_launcher = false;
+    bool heavy_machine_gun = false;
+    bool sniper_rifle = false;
+    bool assault_rifle = false;
+    bool machine_pistol = false;
+    bool shotgun = false;
+    bool scope_assault_rifle = false;
+    bool rail_gun = false;
+};
+
 struct ServerAdditionalConfig
 {
     VoteConfig vote_kick;
@@ -38,6 +51,7 @@ struct ServerAdditionalConfig
     std::optional<float> spawn_life;
     std::optional<float> spawn_armor;
     HitSoundsConfig hit_sounds;
+    WeaponStayExemptionConfig weapon_stay_exemptions;
     std::map<std::string, std::string> item_replacements;
     std::string default_player_weapon;
     std::optional<int> default_player_weapon_ammo;


### PR DESCRIPTION
PR adds the `$DF Weapon Stay Exemptions` dedicated server config option, and resolves #65 

This is something that has been asked for _a lot_ by players over the past few years, particularly for the Rail Driver. The ability to treat the Rail Driver as a superweapon like the fusion, which is exempt from weapon stay by default, in theory might actually make the Rail Driver practical in a competitive setting.

I considered implementing this as simply a `$DF Rail Driver Is Superweapon` toggle, but given how relatively straightforward it was to also support the other weapons, I erred on the side of providing more (completely optional) gameplay customization opportunities to server operators, and expanded the capability to the other weapons.