### PR TITLE
Enable additional built-in commands for single player only

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@ Version 1.9.0 (not released yet)
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
+- Enable commands `drop_clutter`, `drop_entity`, `drop_item`, `teleport`, `pcollide` in single player
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/multi/multi.cpp
+++ b/game_patch/multi/multi.cpp
@@ -74,6 +74,8 @@ CodeInjection multi_start_injection{
     []() {
         void debug_multi_init();
         debug_multi_init();
+        void turn_pcollide_on_init_multi();
+        turn_pcollide_on_init_multi();
     },
 };
 

--- a/game_patch/multi/multi.cpp
+++ b/game_patch/multi/multi.cpp
@@ -74,8 +74,8 @@ CodeInjection multi_start_injection{
     []() {
         void debug_multi_init();
         debug_multi_init();
-        void turn_pcollide_on_init_multi();
-        turn_pcollide_on_init_multi();
+        void reset_restricted_cmds_on_init_multi();
+        reset_restricted_cmds_on_init_multi();
     },
 };
 

--- a/game_patch/os/commands.cpp
+++ b/game_patch/os/commands.cpp
@@ -2,7 +2,7 @@
 #include "console.h"
 #include "../main/main.h"
 #include "../rf/multi.h"
-#include "../rf/entity.h"
+//#include "../rf/entity.h"
 #include "../rf/player/player.h"
 #include "../rf/level.h"
 #include "../misc/misc.h"
@@ -11,7 +11,7 @@
 #include <algorithm>
 #include <patch_common/FunHook.h>
 #include <patch_common/CallHook.h>
-#include <patch_common/CodeInjection.h>
+//#include <patch_common/CodeInjection.h>
 #include <patch_common/AsmWriter.h>
 
 ConsoleCommand2 dot_cmd{
@@ -150,7 +150,6 @@ void console_commands_apply_patches()
     AsmWriter(0x00434FEC, 0x00434FF2).nop();
 
 #ifdef NDEBUG
-    // restrict risky commands unless debug build
     drop_clutter_hook.install();
     drop_entity_hook.install();
     drop_item_hook.install();

--- a/game_patch/os/commands.cpp
+++ b/game_patch/os/commands.cpp
@@ -104,8 +104,6 @@ ConsoleCommand2 pcollide_cmd{
         else {
             rf::local_player->collides_with_world = !rf::local_player->collides_with_world;
             rf::console::print("Player collision with the world is set to {}", rf::local_player->collides_with_world);
-            //int test = rf::entity_lookup_type("ghjkf");
-            //rf::console::print("Entity {}", test);
         }
     },
     "Toggles player collision with the world",
@@ -120,7 +118,6 @@ void reset_restricted_cmds_on_init_multi()
     }
 }
 
-// restrict risky commands unless debug build
 void restrict_mp_command(FunHook<void()>& hook)
 {
     if (rf::is_multi) {
@@ -149,6 +146,7 @@ void console_commands_apply_patches()
     // Allow 'level' command outside of multiplayer game
     AsmWriter(0x00434FEC, 0x00434FF2).nop();
 
+    // restrict risky commands in mp unless debug build
 #ifdef NDEBUG
     drop_clutter_hook.install();
     drop_entity_hook.install();

--- a/game_patch/os/commands.cpp
+++ b/game_patch/os/commands.cpp
@@ -2,7 +2,6 @@
 #include "console.h"
 #include "../main/main.h"
 #include "../rf/multi.h"
-//#include "../rf/entity.h"
 #include "../rf/player/player.h"
 #include "../rf/level.h"
 #include "../misc/misc.h"
@@ -11,7 +10,6 @@
 #include <algorithm>
 #include <patch_common/FunHook.h>
 #include <patch_common/CallHook.h>
-//#include <patch_common/CodeInjection.h>
 #include <patch_common/AsmWriter.h>
 
 ConsoleCommand2 dot_cmd{

--- a/game_patch/rf/entity.h
+++ b/game_patch/rf/entity.h
@@ -399,6 +399,7 @@ namespace rf
     };
 
     static auto& entity_from_handle = addr_as_ref<Entity*(int handle)>(0x00426FC0);
+    static auto& entity_lookup_type = addr_as_ref<int(const char* name)>(0x004251C0);
     static auto& entity_create =
         addr_as_ref<Entity*(int entity_type, const char* name, int parent_handle, const Vector3& pos,
         const Matrix3& orient, int create_flags, int mp_character)>(0x00422360);


### PR DESCRIPTION
This PR adds support for the additional built-in RF console commands listed below in release builds, while restricting their use to single player only for obvious reasons.

Command list:
- `drop_clutter`
- `drop_entity`
- `drop_item`
- `teleport`
- `pcollide`

For the first 4 listed commands, it's sufficient to simply disable access to the command in multiplayer (since they are relevant only for the level/instance in which they are entered). For `pcollide`, I've also added a step when initializing multiplayer to force it on if it's currently off, following the same method already used for the `debug` rendering subcommands.

Two additional very minor changes also included in this PR are:
- Add `entity_lookup_type` method to `entity.h`: Added this because I initially supported `body` in single player as well, but decided against because it's of very little use to players but its behaviour can be confusing. Thought there was no harm in keeping method in `entity.h` anyway though for later utility.
- Remove `difficulty` command from debug build register commands list: Unnecessary because it's already registered in all builds.