### PR TITLE
Add scope and scanner mouse sensitivity modifiers

### DIFF
--- a/common/include/common/config/GameConfig.h
+++ b/common/include/common/config/GameConfig.h
@@ -68,6 +68,8 @@ struct GameConfig
 
     // Audio
     CfgVar<float> level_sound_volume = 1.0f;
+    CfgVar<float> scope_sensitivity_modifier = 1.0f;
+    CfgVar<float> scanner_sensitivity_modifier = 1.0f;
     CfgVar<bool> eax_sound = true;
 
     // Multiplayer

--- a/common/src/config/GameConfig.cpp
+++ b/common/src/config/GameConfig.cpp
@@ -166,6 +166,8 @@ bool GameConfig::visit_vars(T&& visitor, bool is_save)
     result &= visitor(dash_faction_key, "Fast Start", fast_start);
     result &= visitor(dash_faction_key, "Scoreboard Animations", scoreboard_anim);
     result &= visitor(dash_faction_key, "Level Sound Volume", level_sound_volume);
+    result &= visitor(dash_faction_key, "Scope Sensitivity Modifier", scope_sensitivity_modifier);
+    result &= visitor(dash_faction_key, "Scanner Sensitivity Modifier", scanner_sensitivity_modifier);
     result &= visitor(dash_faction_key, "Allow Overwriting Game Files", allow_overwrite_game_files);
     result &= visitor(dash_faction_key, "Version", dash_faction_version);
     result &= visitor(dash_faction_key, "Swap Assault Rifle Controls", swap_assault_rifle_controls);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@ Version 1.9.0 (not released yet)
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
+- Add `scope_sensitivity_modifier` and `scanner_sensitivity_modifier` commands
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/input/mouse.cpp
+++ b/game_patch/input/mouse.cpp
@@ -115,22 +115,28 @@ ConsoleCommand2 ms_cmd{
 float scope_sensitivity_factor = 1.0f;
 float scanner_sensitivity_factor = 1.0f;
 
+constexpr float clamp_sensitivity_modifier(float modifier)
+{
+    constexpr const float min = 0.01f; // prevent division by zero in scope sens
+    constexpr const float max = 4.0f;
+    return std::clamp(modifier, min, max);
+}
+
 void patch_scope_and_scanner_sensitivity()
 {
-    AsmWriter{0x004309B1}.fmul<float>(AsmRegMem(&scope_sensitivity_factor));
-    AsmWriter{0x004309DE}.fmul<float>(AsmRegMem(&scanner_sensitivity_factor));
+    AsmWriter{0x004309B1}.fmul<float>(AsmRegMem{&scope_sensitivity_factor});
+    AsmWriter{0x004309DE}.fmul<float>(AsmRegMem{&scanner_sensitivity_factor});
 }
 
 void update_scope_sensitivity()
 {
-    // prevent division by zero if somehow the modifier gets set to 0
-    float modifier = std::clamp(static_cast<float>(g_game_config.scope_sensitivity_modifier), 0.01f, 4.0f);
+    float modifier = clamp_sensitivity_modifier(g_game_config.scope_sensitivity_modifier);
     scope_sensitivity_factor = rf::scope_sensitivity_constant * (1.0f / modifier);
 }
 
 void update_scanner_sensitivity()
 {
-    float modifier = std::clamp(static_cast<float>(g_game_config.scanner_sensitivity_modifier), 0.01f, 4.0f);
+    float modifier = clamp_sensitivity_modifier(g_game_config.scanner_sensitivity_modifier);
     scanner_sensitivity_factor = rf::scanner_sensitivity_constant * modifier;
 }
 
@@ -138,7 +144,7 @@ ConsoleCommand2 scope_sens_cmd{
     "scope_sensitivity_modifier",
     [](std::optional<float> value_opt) {
         if (value_opt) {
-            float value = std::clamp(value_opt.value(), 0.01f, 4.0f);
+            float value = clamp_sensitivity_modifier(value_opt.value());
             g_game_config.scope_sensitivity_modifier = value;
             g_game_config.save();
             update_scope_sensitivity();
@@ -158,7 +164,7 @@ ConsoleCommand2 scanner_sens_cmd{
     "scanner_sensitivity_modifier",
     [](std::optional<float> value_opt) {
         if (value_opt) {
-            float value = std::clamp(value_opt.value(), 0.01f, 4.0f);
+            float value = clamp_sensitivity_modifier(value_opt.value());
             g_game_config.scanner_sensitivity_modifier = value;
             g_game_config.save();
             update_scanner_sensitivity();

--- a/game_patch/input/mouse.cpp
+++ b/game_patch/input/mouse.cpp
@@ -117,11 +117,8 @@ float scanner_sensitivity_factor = 1.0f;
 
 void patch_scope_and_scanner_sensitivity()
 {
-    AsmWriter scope_writer(0x004309B1);
-    scope_writer.fmul<float>(AsmRegMem(&scope_sensitivity_factor));
-
-    AsmWriter scanner_writer(0x004309DE);
-    scanner_writer.fmul<float>(AsmRegMem(&scanner_sensitivity_factor));
+    AsmWriter{0x004309B1}.fmul<float>(AsmRegMem(&scope_sensitivity_factor));
+    AsmWriter{0x004309DE}.fmul<float>(AsmRegMem(&scanner_sensitivity_factor));
 }
 
 void update_scope_sensitivity()

--- a/game_patch/input/mouse.cpp
+++ b/game_patch/input/mouse.cpp
@@ -144,15 +144,13 @@ ConsoleCommand2 scope_sens_cmd{
     "scope_sensitivity_modifier",
     [](std::optional<float> value_opt) {
         if (value_opt) {
-            float value = clamp_sensitivity_modifier(value_opt.value());
-            g_game_config.scope_sensitivity_modifier = value;
+            g_game_config.scope_sensitivity_modifier = value_opt.value();
             g_game_config.save();
             update_scope_sensitivity();
-            //rf::console::print("Scope sensitivity modifier set to {:.2f}", value);
         }
         else {
             rf::console::print("Scope sensitivity modifier: {:.2f}",
-                               static_cast<float>(g_game_config.scope_sensitivity_modifier));
+                static_cast<float>(clamp_sensitivity_modifier(g_game_config.scope_sensitivity_modifier)));
         }
 
     },
@@ -164,15 +162,14 @@ ConsoleCommand2 scanner_sens_cmd{
     "scanner_sensitivity_modifier",
     [](std::optional<float> value_opt) {
         if (value_opt) {
-            float value = clamp_sensitivity_modifier(value_opt.value());
-            g_game_config.scanner_sensitivity_modifier = value;
+            g_game_config.scanner_sensitivity_modifier = value_opt.value();
             g_game_config.save();
-            update_scanner_sensitivity();
-            //rf::console::print("Scanner sensitivity modifier set to {:.2f}", value);
+            update_scanner_sensitivity();            
         }
         else {
-            rf::console::print("Scanner sensitivity modifier: {:.2f}",
-                               static_cast<float>(g_game_config.scanner_sensitivity_modifier));
+            rf::console::print(
+                "Scanner sensitivity modifier: {:.2f}",
+                static_cast<float>(clamp_sensitivity_modifier(g_game_config.scanner_sensitivity_modifier)));
         }
     },
     "Sets mouse sensitivity modifier used while in a rail scanner.",

--- a/game_patch/rf/input.h
+++ b/game_patch/rf/input.h
@@ -122,6 +122,8 @@ namespace rf
     static auto& mouse_set_visible = addr_as_ref<void(bool visible)>(0x0051E680);
     static auto& key_process_event = addr_as_ref<void(int scan_code, int key_down, int delta_time)>(0x0051E6C0);
 
+    static auto& scope_sensitivity_constant = addr_as_ref<float>(0x005895C0);
+    static auto& scanner_sensitivity_constant = addr_as_ref<float>(0x005893D4);
     static auto& mouse_initialized = addr_as_ref<uint8_t>(0x01885461);
     static auto& direct_input_disabled = addr_as_ref<bool>(0x005A4F88);
     static auto& di_mouse = addr_as_ref<LPDIRECTINPUTDEVICE8A>(0x0188545C);


### PR DESCRIPTION
This PR adds the following new commands:
- `scope_sensitivity_modifier [value]`
- `scanner_sensitivity_modifier [value]`

Both default to 1.0, commands provide players with a method to scale mouse sensitivity when in scopes and scanners.

Resolves #67