### PR TITLE
Add critical hits to multiplayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,22 @@ Configuration example:
     $DF Hitsounds: true
         // Sound used for hit notification
         +Sound ID: 29
-        // max sound packets per second - keep it low to save bandwidth
+        // Max sound packets per second - keep it low to save bandwidth
         +Rate Limit: 10
+    // Enable critical hits
+    $DF Critical Hits: false
+        // Sound used for hit notification
+        +Sound ID: 35
+        // Max sound packets per second - keep it low to save bandwidth
+        +Rate Limit: 10
+        // Duration of damage amp reward on a critical hit
+        +Reward Duration: 1500
+        // Percentage chance of a critical hit
+        +Base Chance Percent: 0.1
+        // Enable dynamic chance bonus based on damage dealt in current life
+        +Use Dynamic Chance Bonus: true
+        // Amount of damage to deal in current life for the max dynamic chance bonus (+ 0.1)
+        +Dynamic Chance Damage Ceiling: 1200
     // Replace all "Shotgun" items with "rail gun" items when loading RFLs
     $DF Item Replacement: "Shotgun" "rail gun"
     // If enabled players are given full ammo when picking up weapon items, can be useful with the Weapons Stay standard option

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@ Version 1.9.0 (not released yet)
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
+- Add `$DF Critical Hits` option in dedicated server config
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -44,6 +44,15 @@
 GameConfig g_game_config;
 HMODULE g_hmodule;
 
+std::mt19937 g_rng;
+
+void initialize_random_generator()
+{
+    // seed rng with the current time
+    auto seed = std::chrono::steady_clock::now().time_since_epoch().count();
+    g_rng.seed(static_cast<unsigned long>(seed));
+}
+
 CallHook<void()> rf_init_hook{
     0x004B27CD,
     []() {
@@ -77,16 +86,6 @@ CodeInjection cleanup_game_hook{
         debug_cleanup();
     },
 };
-
-std::mt19937 rng;
-std::uniform_int_distribution<std::size_t> dist;
-
-void initialize_random_generator()
-{
-    // seed rng with the current time
-    auto seed = std::chrono::steady_clock::now().time_since_epoch().count();
-    rng.seed(static_cast<unsigned long>(seed));
-}
 
 static void maybe_autosave()
 {

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -78,6 +78,16 @@ CodeInjection cleanup_game_hook{
     },
 };
 
+std::mt19937 rng;
+std::uniform_int_distribution<std::size_t> dist;
+
+void initialize_random_generator()
+{
+    // seed rng with the current time
+    auto seed = std::chrono::steady_clock::now().time_since_epoch().count();
+    rng.seed(static_cast<unsigned long>(seed));
+}
+
 static void maybe_autosave()
 {
     static int pending_autosave = 0;
@@ -337,6 +347,9 @@ extern "C" DWORD __declspec(dllexport) Init([[maybe_unused]] void* unused)
     // Init logging and crash dump support first
     init_logging();
     init_crash_handler();
+
+    // Init random number generator
+    initialize_random_generator();
 
     // Enable Data Execution Prevention
     if (!SetProcessDEPPolicy(PROCESS_DEP_ENABLE))

--- a/game_patch/main/main.h
+++ b/game_patch/main/main.h
@@ -1,8 +1,14 @@
 #pragma once
-
+#include <random>
 #include <common/config/GameConfig.h>
 
 extern GameConfig g_game_config;
+
+// random number generator
+extern std::mt19937 rng;
+extern std::uniform_int_distribution<std::size_t> dist;
+void initialize_random_generator();
+
 #ifdef _WINDOWS_
 extern HMODULE g_hmodule;
 #endif

--- a/game_patch/main/main.h
+++ b/game_patch/main/main.h
@@ -5,8 +5,7 @@
 extern GameConfig g_game_config;
 
 // random number generator
-extern std::mt19937 rng;
-extern std::uniform_int_distribution<std::size_t> dist;
+extern std::mt19937 g_rng;
 void initialize_random_generator();
 
 #ifdef _WINDOWS_

--- a/game_patch/misc/player.h
+++ b/game_patch/misc/player.h
@@ -23,6 +23,7 @@ struct PlayerAdditionalData
     bool is_browser = false;
     bool is_muted = false;
     int last_hitsound_sent_ms = 0;
+    int last_critsound_sent_ms = 0;
     std::map<std::string, PlayerNetGameSaveData> saves;
     rf::Vector3 last_teleport_pos;
     rf::TimestampRealtime last_teleport_timestamp;

--- a/game_patch/multi/multi.h
+++ b/game_patch/multi/multi.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <optional>
-#include <deque>
-#include <utility>
 #include <xlog/xlog.h>
 #include "server_internal.h"
 #include "../rf/player/player.h"

--- a/game_patch/multi/multi.h
+++ b/game_patch/multi/multi.h
@@ -18,7 +18,7 @@ struct PlayerStatsNew : rf::PlayerLevelStats
     float num_shots_fired;
     float damage_received;
     float damage_given;
-    std::deque<std::pair<int, float>> damage_log; // track damage events during current life
+    float damage_given_current_life;
 
     void inc_kills()
     {
@@ -31,7 +31,7 @@ struct PlayerStatsNew : rf::PlayerLevelStats
     {
         ++num_deaths;
         current_streak = 0;
-        damage_log.clear();
+        damage_given_current_life = 0;
     }
 
     void add_shots_hit(float add)
@@ -54,7 +54,7 @@ struct PlayerStatsNew : rf::PlayerLevelStats
     void add_damage_given(float damage)
     {
         damage_given += damage;
-        update_damage_log(damage);
+        damage_given_current_life += damage;
     }
 
     [[nodiscard]] float calc_accuracy() const
@@ -75,41 +75,7 @@ struct PlayerStatsNew : rf::PlayerLevelStats
         max_streak = 0;
         damage_received = 0;
         damage_given = 0;
-        damage_log.clear();
-    }
-
-    // track damage events during current life
-    void update_damage_log(float damage)
-    {
-        int current_time = rf::timer_get(1000);
-
-        while (!damage_log.empty() &&
-            (current_time - damage_log.front().first) > g_additional_server_config.critical_hits.dynamic_history_ms)
-        {
-            damage_log.pop_front();
-        }
-
-        damage_log.emplace_back(current_time, damage);
-    }
-
-    // return total damage for the past X ms
-    [[nodiscard]] float get_recent_damage() const
-    {
-        if (!damage_log.empty()) {
-            float total_damage = 0.0f;
-            int current_time = rf::timer_get(1000);
-
-            for (const auto& entry : damage_log) {
-                if ((current_time - entry.first) <= g_additional_server_config.critical_hits.dynamic_history_ms) {
-                    total_damage += entry.second;
-                }
-            }
-            return total_damage;
-        }
-        else {
-            xlog::debug("Damage log is empty, skipping recent damage calculations.");
-            return 0.0f;
-        }
+        damage_given_current_life = 0;
     }
 };
 

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -425,7 +425,6 @@ void send_critical_hit_packet(rf::Player* target)
                       g_additional_server_config.critical_hits.sound_id);
 }
 
-
 FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
     0x0041A350,
     [](rf::Entity* damaged_ep, float damage, int killer_handle, int damage_type, int killer_uid) {
@@ -454,8 +453,8 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
                 float critical_hit_chance = base_chance + bonus_chance;
                 xlog::debug("Critical hit chance: {:.2f}", critical_hit_chance);
 
-                std::uniform_real_distribution<float> dist(0.0f, 1.0f);
-                float random_value = dist(g_rng);
+                std::uniform_real_distribution<float> dist_crit(0.0f, 1.0f);
+                float random_value = dist_crit(g_rng);
                 if (random_value < critical_hit_chance) {
 
                     // Apply amp modifier to the critical hit

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -104,9 +104,9 @@ void load_additional_server_config(rf::Parser& parser)
         if (parser.parse_optional("+Rate Limit:")) {
             g_additional_server_config.critical_hits.rate_limit = parser.parse_uint();
         }
-        //if (parser.parse_optional("+Critical Damage Modifier:")) {
-        //    g_additional_server_config.critical_hits.critical_modifier = parser.parse_float();
-        //}
+        if (parser.parse_optional("+Reward Duration:")) {
+            g_additional_server_config.critical_hits.reward_duration = parser.parse_uint();
+        }
         if (parser.parse_optional("+Base Chance Percent:")) {
             g_additional_server_config.critical_hits.base_chance = parser.parse_float();
         }
@@ -471,9 +471,11 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
                 //damage *= g_additional_server_config.critical_hits.critical_modifier;
                 damage *= (!rf::multi_powerup_has_player(killer_player, 1)) ? 4.0f : 1.0f; // hack, todo get amp bonus
                 //xlog::debug("Crit! Dealt damage: {:.2f}", damage);
-                rf::multi_powerup_add(killer_player, 1, 1500);
+                int amp_time_to_add = rf::multi_powerup_get_time_until(killer_player, 1) +
+                                      g_additional_server_config.critical_hits.reward_duration;
+                rf::multi_powerup_add(killer_player, 1, amp_time_to_add);
                 send_critical_hit_packet(killer_player);
-                  //auto message = std::format("\xA6 You got a critcal shot on {}", damaged_player->name);
+                //auto message = std::format("\xA6 You got a critcal shot on {}", damaged_player->name);
                 //send_chat_line_packet(message.c_str(), killer_player);
             }
         }
@@ -491,6 +493,7 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
             if (g_additional_server_config.hit_sounds.enabled) {
                 send_hit_sound_packet(killer_player);
             }
+            //xlog::warn("Time left on amp: {}", rf::multi_powerup_get_time_until(killer_player, 1));
         }
 
         return real_damage;

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -104,9 +104,9 @@ void load_additional_server_config(rf::Parser& parser)
         if (parser.parse_optional("+Rate Limit:")) {
             g_additional_server_config.critical_hits.rate_limit = parser.parse_uint();
         }
-        if (parser.parse_optional("+Critical Damage Modifier:")) {
-            g_additional_server_config.critical_hits.critical_modifier = parser.parse_float();
-        }
+        //if (parser.parse_optional("+Critical Damage Modifier:")) {
+        //    g_additional_server_config.critical_hits.critical_modifier = parser.parse_float();
+        //}
         if (parser.parse_optional("+Base Chance Percent:")) {
             g_additional_server_config.critical_hits.base_chance = parser.parse_float();
         }
@@ -468,10 +468,12 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
             float random_value = static_cast<float>(dist(rng)) / static_cast<float>(dist.max());
             if (random_value < critical_hit_chance) {
                 // Apply critical hit modifier
-                damage *= g_additional_server_config.critical_hits.critical_modifier;
-                xlog::debug("Crit! Dealt damage: {:.2f}", damage);
+                //damage *= g_additional_server_config.critical_hits.critical_modifier;
+                damage *= (!rf::multi_powerup_has_player(killer_player, 1)) ? 4.0f : 1.0f; // hack, todo get amp bonus
+                //xlog::debug("Crit! Dealt damage: {:.2f}", damage);
+                rf::multi_powerup_add(killer_player, 1, 1500);
                 send_critical_hit_packet(killer_player);
-                //auto message = std::format("\xA6 You got a critcal shot on {}", damaged_player->name);
+                  //auto message = std::format("\xA6 You got a critcal shot on {}", damaged_player->name);
                 //send_chat_line_packet(message.c_str(), killer_player);
             }
         }

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -462,7 +462,7 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
                 1.0f);
 
             float critical_hit_chance = base_chance + bonus_chance;
-            xlog::warn("Critical hit chance: {:.2f}", critical_hit_chance);
+            xlog::debug("Critical hit chance: {:.2f}", critical_hit_chance);
 
             // check if the random roll is a critical hit
             float random_value = static_cast<float>(dist(rng)) / static_cast<float>(dist.max());
@@ -471,8 +471,8 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
                 damage *= g_additional_server_config.critical_hits.critical_modifier;
                 xlog::debug("Crit! Dealt damage: {:.2f}", damage);
                 send_critical_hit_packet(killer_player);
-                auto message = std::format("\xA6 You got a critcal shot on {}", damaged_player->name);
-                send_chat_line_packet(message.c_str(), killer_player);
+                //auto message = std::format("\xA6 You got a critcal shot on {}", damaged_player->name);
+                //send_chat_line_packet(message.c_str(), killer_player);
             }
         }
 

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -465,7 +465,8 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
             xlog::debug("Critical hit chance: {:.2f}", critical_hit_chance);
 
             // check if the random roll is a critical hit
-            float random_value = static_cast<float>(dist(rng)) / static_cast<float>(dist.max());
+            std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+            float random_value = dist(g_rng);
             if (random_value < critical_hit_chance) {
                 // Apply critical hit modifier
                 //damage *= g_additional_server_config.critical_hits.critical_modifier;

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -101,9 +101,6 @@ void load_additional_server_config(rf::Parser& parser)
         if (parser.parse_optional("+Attacker Sound ID:")) {
             g_additional_server_config.critical_hits.sound_id = parser.parse_uint();
         }
-        /* if (parser.parse_optional("+Victim Sound ID:")) {
-            g_additional_server_config.critical_hits.sound_id_damaged = parser.parse_uint();
-        }*/
         if (parser.parse_optional("+Rate Limit:")) {
             g_additional_server_config.critical_hits.rate_limit = parser.parse_uint();
         }
@@ -115,9 +112,6 @@ void load_additional_server_config(rf::Parser& parser)
         }
         if (parser.parse_optional("+Use Dynamic Chance Bonus:")) {
             g_additional_server_config.critical_hits.dynamic_scale = parser.parse_bool();
-        }
-        if (parser.parse_optional("+Dynamic Chance History:")) {
-            g_additional_server_config.critical_hits.dynamic_history_ms = parser.parse_int();
         }
         if (parser.parse_optional("+Dynamic Chance Damage Ceiling:")) {
             g_additional_server_config.critical_hits.dynamic_damage_for_max_bonus = parser.parse_float();
@@ -454,19 +448,21 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
         if (rf::is_server && g_additional_server_config.critical_hits.enabled && is_pvp_damage && damage > 0.0f) {
             float base_chance = g_additional_server_config.critical_hits.base_chance;
             float bonus_chance = 0.0f;
-            float recent_damage = 0.0f;
+            float total_damage_current_life = 0.0f;
 
             if (killer_player && killer_player->stats) {
                 auto* killer_stats = static_cast<PlayerStatsNew*>(killer_player->stats);
-                recent_damage = killer_stats->get_recent_damage();
+                total_damage_current_life =
+                    killer_stats->damage_given_current_life; // Use the total damage in the current life
             }
 
             // if damage >= 1000, they get the full 10% bonus
-            bonus_chance = 0.1f * std::min(recent_damage /
-                g_additional_server_config.critical_hits.dynamic_damage_for_max_bonus, 1.0f);
+            bonus_chance = 0.1f * std::min(
+                total_damage_current_life / g_additional_server_config.critical_hits.dynamic_damage_for_max_bonus,
+                1.0f);
 
             float critical_hit_chance = base_chance + bonus_chance;
-            xlog::debug("Critical hit chance: {:.2f}", critical_hit_chance);
+            xlog::warn("Critical hit chance: {:.2f}", critical_hit_chance);
 
             // check if the random roll is a critical hit
             float random_value = static_cast<float>(dist(rng)) / static_cast<float>(dist.max());
@@ -475,6 +471,8 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
                 damage *= g_additional_server_config.critical_hits.critical_modifier;
                 xlog::debug("Crit! Dealt damage: {:.2f}", damage);
                 send_critical_hit_packet(killer_player);
+                auto message = std::format("\xA6 You got a critcal shot on {}", damaged_player->name);
+                send_chat_line_packet(message.c_str(), killer_player);
             }
         }
 

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -452,7 +452,7 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
         }
 
         // Critical hit logic
-        if (g_additional_server_config.critical_hits.enabled) {
+        if (rf::is_server && g_additional_server_config.critical_hits.enabled && is_pvp_damage && damage > 0.0f) {
             float base_chance = g_additional_server_config.critical_hits.base_chance;
             float additional_chance = 0.0f;
 

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -30,12 +30,10 @@ struct CriticalHitsConfig
 {
     bool enabled = false;
     int sound_id = 35;
-    //int sound_id_damaged = 47;
     int rate_limit = 10;
     float critical_modifier = 3.0f;
     float base_chance = 0.1f;
     bool dynamic_scale = true;
-    int dynamic_history_ms = 20000;
     float dynamic_damage_for_max_bonus = 1200.0f;
 };
 

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -30,7 +30,7 @@ struct CriticalHitsConfig
 {
     bool enabled = false;
     int sound_id = 35;
-    int sound_id_damaged = 55;
+    int sound_id_damaged = 47;
     int rate_limit = 10;
     float critical_modifier = 3.0f;
     float base_chance = 0.1f;

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -31,7 +31,7 @@ struct CriticalHitsConfig
     bool enabled = false;
     int sound_id = 35;
     int rate_limit = 10;
-    //float critical_modifier = 3.0f;
+    int reward_duration = 1500;
     float base_chance = 0.1f;
     bool dynamic_scale = true;
     float dynamic_damage_for_max_bonus = 1200.0f;

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -26,6 +26,17 @@ struct HitSoundsConfig
     int rate_limit = 10;
 };
 
+struct CriticalHitsConfig
+{
+    bool enabled = false;
+    int sound_id = 35;
+    int sound_id_damaged = 55;
+    int rate_limit = 10;
+    float critical_modifier = 3.0f;
+    float base_chance = 0.1f;
+    bool dynamic_scale = false;
+};
+
 struct ServerAdditionalConfig
 {
     VoteConfig vote_kick;
@@ -38,6 +49,7 @@ struct ServerAdditionalConfig
     std::optional<float> spawn_life;
     std::optional<float> spawn_armor;
     HitSoundsConfig hit_sounds;
+    CriticalHitsConfig critical_hits;
     std::map<std::string, std::string> item_replacements;
     std::string default_player_weapon;
     std::optional<int> default_player_weapon_ammo;

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -35,6 +35,8 @@ struct CriticalHitsConfig
     float critical_modifier = 3.0f;
     float base_chance = 0.1f;
     bool dynamic_scale = true;
+    int dynamic_history_ms = 20000;
+    float dynamic_damage_for_max_bonus = 1200.0f;
 };
 
 struct ServerAdditionalConfig

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -31,7 +31,7 @@ struct CriticalHitsConfig
     bool enabled = false;
     int sound_id = 35;
     int rate_limit = 10;
-    float critical_modifier = 3.0f;
+    //float critical_modifier = 3.0f;
     float base_chance = 0.1f;
     bool dynamic_scale = true;
     float dynamic_damage_for_max_bonus = 1200.0f;

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -30,7 +30,7 @@ struct CriticalHitsConfig
 {
     bool enabled = false;
     int sound_id = 35;
-    int sound_id_damaged = 47;
+    //int sound_id_damaged = 47;
     int rate_limit = 10;
     float critical_modifier = 3.0f;
     float base_chance = 0.1f;

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -34,7 +34,7 @@ struct CriticalHitsConfig
     int rate_limit = 10;
     float critical_modifier = 3.0f;
     float base_chance = 0.1f;
-    bool dynamic_scale = false;
+    bool dynamic_scale = true;
 };
 
 struct ServerAdditionalConfig

--- a/game_patch/rf/misc.h
+++ b/game_patch/rf/misc.h
@@ -10,4 +10,7 @@ namespace rf
     static auto& default_player_weapon = addr_as_ref<String>(0x007C7600);
 
     static auto& get_file_checksum = addr_as_ref<unsigned(const char* filename)>(0x00436630);
-}
+
+    static auto& g_multi_damage_modifier = addr_as_ref<float>(0x0059F7E0);
+
+    }

--- a/game_patch/rf/multi.h
+++ b/game_patch/rf/multi.h
@@ -169,6 +169,8 @@ namespace rf
     static auto& multi_entity_is_female = addr_as_ref<bool(int mp_character_idx)>(0x004762C0);
     static auto& multi_powerup_add = addr_as_ref<void(Player* pp, int powerup_type, int time_ms)>(0x00480050);
     static auto& multi_powerup_has_player = addr_as_ref<bool(Player* pp, int powerup_type)>(0x004802B0);
+    static auto& multi_powerup_get_time_until = addr_as_ref<int(Player* pp, int powerup_type)>(0x004802D0);
+
 
     static auto& netgame = addr_as_ref<NetGameInfo>(0x0064EC28);
     static auto& is_multi = addr_as_ref<bool>(0x0064ECB9);

--- a/game_patch/rf/multi.h
+++ b/game_patch/rf/multi.h
@@ -167,6 +167,8 @@ namespace rf
     static auto& multi_kill_local_player = addr_as_ref<void()>(0x004757A0);
     static auto& send_game_info_req_packet = addr_as_ref<void(const NetAddr& addr)>(0x0047B450);
     static auto& multi_entity_is_female = addr_as_ref<bool(int mp_character_idx)>(0x004762C0);
+    static auto& multi_powerup_add = addr_as_ref<void(Player* pp, int powerup_type, int time_ms)>(0x00480050);
+    static auto& multi_powerup_has_player = addr_as_ref<bool(Player* pp, int powerup_type)>(0x004802B0);
 
     static auto& netgame = addr_as_ref<NetGameInfo>(0x0064EC28);
     static auto& is_multi = addr_as_ref<bool>(0x0064ECB9);


### PR DESCRIPTION
This PR adds critical hits to Dash servers optionally (default is off). This logic is inspired by Team Fortress 2, though it works a little differently. I wrote this feature in order to add a fun twist to the gameplay in the FactionFiles DM pub and it's generally been well received, so I thought I might as well PR it over so other server operators can try it out too if they wish.

Here's an explanation of the logic with default values:
- When you deal damage to an opponent, you have a 10% chance of it being a critical hit.
- Critical hits deal 4x damage AND grant you a damage amp for 1.5 seconds.
- Your chance of getting a critical hit goes up based on the amount of damage you've dealt since your last death. The bonus chance is +10% if you've dealt at least 1200 damage since your last death, which boosts your chance of a critical hit to 20%.
- When you've dealt 0 - 1200 damage since your last death, the bonus scales based on that standard. For example, if you've dealt 600 damage, your chance of a critical hit is 15%. If you've dealt 300, it's 12.5%, etc.

Configurable items in dedicated_server.txt are:

```
    // Enable critical hits
    $DF Critical Hits: false
        // Sound used for hit notification
        +Sound ID: 35
        // Max sound packets per second - keep it low to save bandwidth
        +Rate Limit: 10
        // Duration of damage amp reward on a critical hit
        +Reward Duration: 1500
        // Percentage chance of a critical hit
        +Base Chance Percent: 0.1
        // Enable dynamic chance bonus based on damage dealt in current life
        +Use Dynamic Chance Bonus: true
        // Amount of damage to deal in current life for the max dynamic chance bonus (+ 0.1)
        +Dynamic Chance Damage Ceiling: 1200
```

Note: This PR does use the same RNG code as #271, but it is _identical_, so there should be no conflict in merging both of them.