### PR TITLE
Add commonly requested multiplayer visibility options (with server approval required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ Configuration example:
     $DF Force Player Character: "enviro_parker"
     // Maximal horizontal FOV that clients can use for level rendering (unlimited by default)
     //$DF Max FOV: 125
+    // Allow clients to use `mesh_fullbright`
+    $DF Allow Fullbright Meshes: false
+    // Allow clients to use `lightmaps_only`
+    $DF Allow Lightmaps Only Mode: false
     // If enabled a private message with player statistics is sent after each round.
     //$DF Send Player Stats Message: true
     // Send a chat message to players when they join the server ($PLAYER is replaced by player name)

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Configuration example:
     $DF Allow Fullbright Meshes: false
     // Allow clients to use `lightmaps_only`
     $DF Allow Lightmaps Only Mode: false
+    // Allow clients to use `disable_screenshake`
+    $DF Allow Disable Screenshake: false
     // If enabled a private message with player statistics is sent after each round.
     //$DF Send Player Stats Message: true
     // Send a chat message to players when they join the server ($PLAYER is replaced by player name)

--- a/common/include/common/config/GameConfig.h
+++ b/common/include/common/config/GameConfig.h
@@ -61,6 +61,9 @@ struct GameConfig
     CfgVar<bool> glares = true;
     CfgVar<bool> show_enemy_bullets = true;
 
+    CfgVar<bool> try_mesh_fullbright = false;
+    CfgVar<bool> try_disable_textures = false;
+
     static constexpr float min_fov = 75.0f;
     static constexpr float max_fov = 160.0f;
     CfgVar<float> horz_fov{0.0f, [](float val) { return val == 0.0f ? 0.0f : std::clamp(val, min_fov, max_fov); }};

--- a/common/include/common/config/GameConfig.h
+++ b/common/include/common/config/GameConfig.h
@@ -62,7 +62,7 @@ struct GameConfig
     CfgVar<bool> show_enemy_bullets = true;
 
     CfgVar<bool> try_mesh_fullbright = false;
-    CfgVar<bool> try_disable_textures = false;
+    CfgVar<bool> try_lightmaps_only = false;
 
     static constexpr float min_fov = 75.0f;
     static constexpr float max_fov = 160.0f;

--- a/common/include/common/config/GameConfig.h
+++ b/common/include/common/config/GameConfig.h
@@ -63,7 +63,7 @@ struct GameConfig
 
     CfgVar<bool> try_mesh_fullbright = false;
     CfgVar<bool> try_lightmaps_only = false;
-    CfgVar<bool> try_disable_ss = false;
+    CfgVar<bool> try_disable_screenshake = false;
 
     static constexpr float min_fov = 75.0f;
     static constexpr float max_fov = 160.0f;

--- a/common/include/common/config/GameConfig.h
+++ b/common/include/common/config/GameConfig.h
@@ -63,6 +63,7 @@ struct GameConfig
 
     CfgVar<bool> try_mesh_fullbright = false;
     CfgVar<bool> try_lightmaps_only = false;
+    CfgVar<bool> try_disable_ss = false;
 
     static constexpr float min_fov = 75.0f;
     static constexpr float max_fov = 160.0f;

--- a/common/src/config/GameConfig.cpp
+++ b/common/src/config/GameConfig.cpp
@@ -175,6 +175,7 @@ bool GameConfig::visit_vars(T&& visitor, bool is_save)
     result &= visitor(dash_faction_key, "Show Enemy Bullets", show_enemy_bullets);
     result &= visitor(dash_faction_key, "Lightmaps Only", try_lightmaps_only);
     result &= visitor(dash_faction_key, "Fullbright Meshes", try_mesh_fullbright);
+    result &= visitor(dash_faction_key, "Disable Screen Shake", try_disable_ss);
     result &= visitor(dash_faction_key, "Keep Launcher Open", keep_launcher_open);
     result &= visitor(dash_faction_key, "Skip Cutscene Control", skip_cutscene_ctrl);
     result &= visitor(dash_faction_key, "Damage Screen Flash", damage_screen_flash);

--- a/common/src/config/GameConfig.cpp
+++ b/common/src/config/GameConfig.cpp
@@ -173,6 +173,8 @@ bool GameConfig::visit_vars(T&& visitor, bool is_save)
     result &= visitor(dash_faction_key, "Glares", glares);
     result &= visitor(dash_faction_key, "Linear Pitch", linear_pitch);
     result &= visitor(dash_faction_key, "Show Enemy Bullets", show_enemy_bullets);
+    result &= visitor(dash_faction_key, "Lightmaps Only", try_lightmaps_only);
+    result &= visitor(dash_faction_key, "Fullbright Meshes", try_mesh_fullbright);
     result &= visitor(dash_faction_key, "Keep Launcher Open", keep_launcher_open);
     result &= visitor(dash_faction_key, "Skip Cutscene Control", skip_cutscene_ctrl);
     result &= visitor(dash_faction_key, "Damage Screen Flash", damage_screen_flash);

--- a/common/src/config/GameConfig.cpp
+++ b/common/src/config/GameConfig.cpp
@@ -175,7 +175,7 @@ bool GameConfig::visit_vars(T&& visitor, bool is_save)
     result &= visitor(dash_faction_key, "Show Enemy Bullets", show_enemy_bullets);
     result &= visitor(dash_faction_key, "Lightmaps Only", try_lightmaps_only);
     result &= visitor(dash_faction_key, "Fullbright Meshes", try_mesh_fullbright);
-    result &= visitor(dash_faction_key, "Disable Screen Shake", try_disable_ss);
+    result &= visitor(dash_faction_key, "Disable Screenshake", try_disable_screenshake);
     result &= visitor(dash_faction_key, "Keep Launcher Open", keep_launcher_open);
     result &= visitor(dash_faction_key, "Skip Cutscene Control", skip_cutscene_ctrl);
     result &= visitor(dash_faction_key, "Damage Screen Flash", damage_screen_flash);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,8 @@ Version 1.9.0 (not released yet)
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
+- Add `lightmaps_only` and `mesh_fullbright` commands
+- Add `$DF Allow Lightmaps Only Mode` and `$DF Allow Fullbright Meshes` dedicated server config options
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,8 +43,8 @@ Version 1.9.0 (not released yet)
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
-- Add `lightmaps_only` and `mesh_fullbright` commands
-- Add `$DF Allow Lightmaps Only Mode` and `$DF Allow Fullbright Meshes` dedicated server config options
+- Add `lightmaps_only`, `mesh_fullbright`, and `disable_screenshake` commands
+- Add `$DF Allow Lightmaps Only Mode`, `$DF Allow Fullbright Meshes`, and `$DF Allow Disable Screenshake` dedicated server config options
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/graphics/gr.cpp
+++ b/game_patch/graphics/gr.cpp
@@ -147,51 +147,38 @@ ConsoleCommand2 gamma_cmd{
     "gamma [value]",
 };
 
-void evaluate_disable_textures()
+void evaluate_lightmaps_only()
 {
-    bool server_side_restrict_disable_textures =
+    bool server_side_restrict_lightmaps_only =
         rf::is_multi && !rf::is_server && get_df_server_info() && !get_df_server_info()->allow_lmap;
 
-    if (server_side_restrict_disable_textures) {
-        if (g_game_config.try_disable_textures) {
-            xlog::warn("This server does not allow you to disable level textures!");
+    if (server_side_restrict_lightmaps_only) {
+        if (g_game_config.try_lightmaps_only) {
+            xlog::warn("This server does not allow you to use lightmap only mode!");
             rf::gr::show_lightmaps = false;
             rf::g_cache_clear();
         }
     }
     else {
-        if (rf::gr::show_lightmaps != g_game_config.try_disable_textures) {
-            rf::gr::show_lightmaps = g_game_config.try_disable_textures;
+        if (rf::gr::show_lightmaps != g_game_config.try_lightmaps_only) {
+            rf::gr::show_lightmaps = g_game_config.try_lightmaps_only;
             rf::g_cache_clear();
         }
     }
 }
 
-ConsoleCommand2 picmip_cmd{
-    "picmip",
-    [](std::optional<int> picmip_opt) {
-        if (picmip_opt) {
-            rf::gr::bm_set_resolution_level_for_all(picmip_opt.value_or(0));
-            //rf::local_player->settings.textures_resolution_level = picmip_opt.value_or(rf::local_player->settings.textures_resolution_level);
-        }
-        rf::console::print("Current texture resolution reduction factor: {}",
-            rf::local_player->settings.textures_resolution_level);
-    },
-    "Set texture resolution reduction factor",
-};
-
-ConsoleCommand2 disable_textures_cmd{
-    "disable_textures",
+ConsoleCommand2 lightmaps_only_cmd{
+    "lightmaps_only",
     []() {
-        g_game_config.try_disable_textures = !g_game_config.try_disable_textures;
+        g_game_config.try_lightmaps_only = !g_game_config.try_lightmaps_only;
         g_game_config.save();
 
-        evaluate_disable_textures();
+        evaluate_lightmaps_only();
 
-        rf::console::print("Level textures are {}", g_game_config.try_disable_textures ?
-            "disabled. In multiplayer, this will only apply if the server allows it." : "enabled.");
+        rf::console::print("Lightmap only mode is {}", g_game_config.try_lightmaps_only ?
+            "enabled. In multiplayer, this will only apply if the server allows it." : "disabled.");
     },
-    "Disable level textures for visibility. In multiplayer, this is only available if the server allows it.",
+    "Render only lightmaps for level geometry (no textures). In multiplayer, this is only available if the server allows it.",
 };
 
 FunHook<float(const rf::Vector3&)> gr_get_apparent_distance_from_camera_hook{
@@ -376,8 +363,7 @@ void gr_apply_patch()
     // Commands
     fov_cmd.register_cmd();
     gamma_cmd.register_cmd();
-    picmip_cmd.register_cmd();
-    disable_textures_cmd.register_cmd();
+    lightmaps_only_cmd.register_cmd();
     fullscreen_cmd.register_cmd();
     windowed_cmd.register_cmd();
     nearest_texture_filtering_cmd.register_cmd();

--- a/game_patch/graphics/gr.cpp
+++ b/game_patch/graphics/gr.cpp
@@ -154,7 +154,7 @@ void evaluate_lightmaps_only()
 
     if (server_side_restrict_lightmaps_only) {
         if (g_game_config.try_lightmaps_only) {
-            xlog::warn("This server does not allow you to use lightmap only mode!");
+            rf::console::print("This server does not allow you to use lightmap only mode!");
             rf::gr::show_lightmaps = false;
             rf::g_cache_clear();
         }

--- a/game_patch/graphics/gr.cpp
+++ b/game_patch/graphics/gr.cpp
@@ -147,29 +147,24 @@ ConsoleCommand2 gamma_cmd{
     "gamma [value]",
 };
 
-//need to check on multi start and level init
 void evaluate_disable_textures()
 {
     bool server_side_restrict_disable_textures =
-        rf::is_multi && !rf::is_server && get_df_server_info() && !get_df_server_info().value().allow_lmap;
-    // server doesn't allow but we have it on
-    if (server_side_restrict_disable_textures && g_game_config.try_disable_textures) {
-        xlog::warn("This server does not allow you to disable level textures!");
-        rf::gr::show_lightmaps = false;
-        rf::g_cache_clear();
+        rf::is_multi && !rf::is_server && get_df_server_info() && !get_df_server_info()->allow_lmap;
+
+    if (server_side_restrict_disable_textures) {
+        if (g_game_config.try_disable_textures) {
+            xlog::warn("This server does not allow you to disable level textures!");
+            rf::gr::show_lightmaps = false;
+            rf::g_cache_clear();
+        }
     }
-    // server doesn't care, we want it on, but it's currently off
-    else if (g_game_config.try_disable_textures && !rf::gr::show_lightmaps) {
-        rf::gr::show_lightmaps = true;
-        rf::g_cache_clear();
+    else {
+        if (rf::gr::show_lightmaps != g_game_config.try_disable_textures) {
+            rf::gr::show_lightmaps = g_game_config.try_disable_textures;
+            rf::g_cache_clear();
+        }
     }
-    // server doesn't care, we want it off, but it's currently on
-    else if (!g_game_config.try_disable_textures && rf::gr::show_lightmaps) {
-        rf::gr::show_lightmaps = false;
-        rf::g_cache_clear();
-    }
-    else {}
-    // otherwise we have nothing we need to do, empty else to avoid warning
 }
 
 ConsoleCommand2 picmip_cmd{

--- a/game_patch/graphics/gr.cpp
+++ b/game_patch/graphics/gr.cpp
@@ -9,10 +9,13 @@
 #include <patch_common/CodeInjection.h>
 #include <patch_common/ShortTypes.h>
 #include <patch_common/AsmWriter.h>
+#include <xlog/xlog.h>
 #include "../os/console.h"
 #include "../main/main.h"
 #include "../multi/multi.h"
 #include "../rf/gr/gr.h"
+#include "../rf/level.h"
+#include "../rf/geometry.h"
 #include "../rf/player/player.h"
 #include "../rf/multi.h"
 #include "../rf/os/os.h"
@@ -142,6 +145,28 @@ ConsoleCommand2 gamma_cmd{
     },
     "Sets gamma.",
     "gamma [value]",
+};
+
+ConsoleCommand2 picmip_cmd{
+    "picmip",
+    [](std::optional<int> picmip_opt) {
+        if (picmip_opt) {
+            rf::gr::bm_set_resolution_level_for_all(picmip_opt.value_or(0));
+            //rf::local_player->settings.textures_resolution_level = picmip_opt.value_or(rf::local_player->settings.textures_resolution_level);
+        }
+        rf::console::print("Current texture resolution reduction factor: {}",
+            rf::local_player->settings.textures_resolution_level);
+    },
+    "Set texture resolution reduction factor",
+};
+
+ConsoleCommand2 disable_textures_cmd{
+    "toggle_level_textures",
+    []() {
+        rf::gr::show_lightmaps = !rf::gr::show_lightmaps;
+        rf::g_cache_clear();
+    },
+    "Disable level textures for increased visibility. In multiplayer, only available if allowed by server.",
 };
 
 FunHook<float(const rf::Vector3&)> gr_get_apparent_distance_from_camera_hook{
@@ -326,6 +351,8 @@ void gr_apply_patch()
     // Commands
     fov_cmd.register_cmd();
     gamma_cmd.register_cmd();
+    picmip_cmd.register_cmd();
+    disable_textures_cmd.register_cmd();
     fullscreen_cmd.register_cmd();
     windowed_cmd.register_cmd();
     nearest_texture_filtering_cmd.register_cmd();

--- a/game_patch/graphics/gr.h
+++ b/game_patch/graphics/gr.h
@@ -4,6 +4,7 @@
 #include "../rf/gr/gr.h"
 
 void gr_apply_patch();
+void evaluate_disable_textures();
 int gr_font_get_default();
 void gr_font_set_default(int font_id);
 bool gr_set_render_target(int bm_handle);

--- a/game_patch/graphics/gr.h
+++ b/game_patch/graphics/gr.h
@@ -4,7 +4,7 @@
 #include "../rf/gr/gr.h"
 
 void gr_apply_patch();
-void evaluate_disable_textures();
+void evaluate_lightmaps_only();
 int gr_font_get_default();
 void gr_font_set_default(int font_id);
 bool gr_set_render_target(int bm_handle);

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -158,6 +158,9 @@ FunHook<void(bool)> level_init_post_hook{
         level_init_post_hook.call_target(transition);
         xlog::info("Level loaded: {}{}", rf::level.filename, transition ? " (transition)" : "");
         evaluate_fullbright_meshes();
+        if (g_game_config.try_disable_textures) {
+            evaluate_disable_textures();
+        }  
     },
 };
 

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -158,8 +158,8 @@ FunHook<void(bool)> level_init_post_hook{
         level_init_post_hook.call_target(transition);
         xlog::info("Level loaded: {}{}", rf::level.filename, transition ? " (transition)" : "");
         evaluate_fullbright_meshes();
-        if (g_game_config.try_disable_textures) {
-            evaluate_disable_textures();
+        if (g_game_config.try_lightmaps_only) {
+            evaluate_lightmaps_only();
         }  
     },
 };

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -160,6 +160,9 @@ FunHook<void(bool)> level_init_post_hook{
         evaluate_fullbright_meshes();
         if (g_game_config.try_lightmaps_only) {
             evaluate_lightmaps_only();
+        }
+        if (g_game_config.try_disable_ss) {
+            evaluate_restrict_disable_ss();
         }  
     },
 };

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -157,6 +157,7 @@ FunHook<void(bool)> level_init_post_hook{
     [](bool transition) {
         level_init_post_hook.call_target(transition);
         xlog::info("Level loaded: {}{}", rf::level.filename, transition ? " (transition)" : "");
+        evaluate_fullbright_meshes();
     },
 };
 

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -161,7 +161,7 @@ FunHook<void(bool)> level_init_post_hook{
         if (g_game_config.try_lightmaps_only) {
             evaluate_lightmaps_only();
         }
-        if (g_game_config.try_disable_ss) {
+        if (g_game_config.try_disable_screenshake) {
             evaluate_restrict_disable_ss();
         }  
     },

--- a/game_patch/main/main.h
+++ b/game_patch/main/main.h
@@ -6,3 +6,5 @@ extern GameConfig g_game_config;
 #ifdef _WINDOWS_
 extern HMODULE g_hmodule;
 #endif
+
+void evaluate_fullbright_meshes();

--- a/game_patch/misc/camera.cpp
+++ b/game_patch/misc/camera.cpp
@@ -32,7 +32,7 @@ FunHook<void(rf::Camera*, float, float)> camera_shake_hook{
     0x0040E0B0,
     [](rf::Camera* cp, float amplitude, float time_seconds) {
 
-        if (g_game_config.try_disable_ss && !server_side_restrict_disable_ss) {
+        if (g_game_config.try_disable_screenshake && !server_side_restrict_disable_ss) {
             return;
         }
 
@@ -46,7 +46,7 @@ void evaluate_restrict_disable_ss()
         rf::is_multi && !rf::is_server && get_df_server_info() && !get_df_server_info()->allow_no_ss;
 
     if (server_side_restrict_disable_ss) {
-        if (g_game_config.try_disable_ss) {
+        if (g_game_config.try_disable_screenshake) {
             rf::console::print("This server does not allow you to disable screenshake!");
         }
     }
@@ -55,13 +55,13 @@ void evaluate_restrict_disable_ss()
 ConsoleCommand2 disable_screenshake_cmd{
     "disable_screenshake",
     []() {
-        g_game_config.try_disable_ss = !g_game_config.try_disable_ss;
+        g_game_config.try_disable_screenshake = !g_game_config.try_disable_screenshake;
         g_game_config.save();
 
         evaluate_restrict_disable_ss();
 
         rf::console::print("Screenshake is {}",
-                           g_game_config.try_disable_ss
+                           g_game_config.try_disable_screenshake
                                ? "disabled. In multiplayer, this will only apply if the server allows it."
                                : "enabled.");
     },

--- a/game_patch/misc/camera.cpp
+++ b/game_patch/misc/camera.cpp
@@ -1,11 +1,18 @@
 #include <patch_common/AsmWriter.h>
 #include <patch_common/FunHook.h>
+#include "../main/main.h"
+#include "../rf/multi.h"
+#include "../os/console.h"
+#include "../misc/misc.h"
+#include "../multi/multi.h"
 #include "../rf/player/player.h"
 #include "../rf/os/frametime.h"
 
 constexpr auto screen_shake_fps = 150.0f;
 
 static float g_camera_shake_factor = 0.6f;
+
+bool server_side_restrict_disable_ss = false;
 
 FunHook<void(rf::Camera*)> camera_update_shake_hook{
     0x0040DB70,
@@ -20,6 +27,47 @@ FunHook<void(rf::Camera*)> camera_update_shake_hook{
     },
 };
 
+// called whenever screenshake is used, weapons, explosions, fall damage, events, etc.
+FunHook<void(rf::Camera*, float, float)> camera_shake_hook{
+    0x0040E0B0,
+    [](rf::Camera* cp, float amplitude, float time_seconds) {
+
+        if (g_game_config.try_disable_ss && !server_side_restrict_disable_ss) {
+            return;
+        }
+
+        camera_shake_hook.call_target(cp, amplitude, time_seconds);
+    }
+};
+
+void evaluate_restrict_disable_ss()
+{
+    server_side_restrict_disable_ss =
+        rf::is_multi && !rf::is_server && get_df_server_info() && !get_df_server_info()->allow_no_ss;
+
+    if (server_side_restrict_disable_ss) {
+        if (g_game_config.try_disable_ss) {
+            rf::console::print("This server does not allow you to disable screenshake!");
+        }
+    }
+}
+
+ConsoleCommand2 disable_screenshake_cmd{
+    "disable_screenshake",
+    []() {
+        g_game_config.try_disable_ss = !g_game_config.try_disable_ss;
+        g_game_config.save();
+
+        evaluate_restrict_disable_ss();
+
+        rf::console::print("Screenshake is {}",
+                           g_game_config.try_disable_ss
+                               ? "disabled. In multiplayer, this will only apply if the server allows it."
+                               : "enabled.");
+    },
+    "Disable screenshake. In multiplayer, this is only applied if the server allows it.",
+};
+
 void camera_do_patch()
 {
     // Fix crash when executing camera2 command in main menu
@@ -27,4 +75,8 @@ void camera_do_patch()
 
     // Fix screen shake caused by some weapons (eg. Assault Rifle)
     write_mem_ptr(0x0040DBCC + 2, &g_camera_shake_factor);
+
+    // handle turning off screen shake
+    disable_screenshake_cmd.register_cmd();
+    camera_shake_hook.install();
 }

--- a/game_patch/misc/misc.h
+++ b/game_patch/misc/misc.h
@@ -10,3 +10,4 @@ void start_join_multi_game_sequence(const rf::NetAddr& addr, const std::string& 
 bool multi_join_game(const rf::NetAddr& addr, const std::string& password);
 void ui_get_string_size(int* w, int* h, const char* s, int s_len, int font_num);
 void g_solid_render_ui();
+void evaluate_restrict_disable_ss();

--- a/game_patch/multi/multi.cpp
+++ b/game_patch/multi/multi.cpp
@@ -14,6 +14,8 @@
 #include "../rf/entity.h"
 #include "../rf/ai.h"
 #include "../rf/item.h"
+#include "../main/main.h"
+#include "../graphics/gr.h"
 
 // Note: this must be called from DLL init function
 // Note: we can't use global variable because that would lead to crash when launcher loads this DLL to check dependencies
@@ -74,6 +76,9 @@ CodeInjection multi_start_injection{
     []() {
         void debug_multi_init();
         debug_multi_init();
+        if (g_game_config.try_disable_textures) {
+            evaluate_disable_textures();
+        }        
     },
 };
 

--- a/game_patch/multi/multi.cpp
+++ b/game_patch/multi/multi.cpp
@@ -76,8 +76,8 @@ CodeInjection multi_start_injection{
     []() {
         void debug_multi_init();
         debug_multi_init();
-        if (g_game_config.try_disable_textures) {
-            evaluate_disable_textures();
+        if (g_game_config.try_lightmaps_only) {
+            evaluate_lightmaps_only();
         }        
     },
 };

--- a/game_patch/multi/multi.h
+++ b/game_patch/multi/multi.h
@@ -76,6 +76,8 @@ struct DashFactionServerInfo
     uint8_t version_minor = 0;
     bool saving_enabled = false;
     std::optional<float> max_fov;
+    bool allow_fb_mesh = false;
+    bool allow_lmap = false;
 };
 
 void multi_level_download_update();

--- a/game_patch/multi/multi.h
+++ b/game_patch/multi/multi.h
@@ -78,6 +78,7 @@ struct DashFactionServerInfo
     std::optional<float> max_fov;
     bool allow_fb_mesh = false;
     bool allow_lmap = false;
+    bool allow_no_ss = false;
 };
 
 void multi_level_download_update();

--- a/game_patch/multi/network.cpp
+++ b/game_patch/multi/network.cpp
@@ -667,8 +667,8 @@ struct DashFactionJoinAcceptPacketExt
         none           = 0,
         saving_enabled = 1,
         max_fov        = 2,
-        allow_fb_mesh  = 3,
-        allow_lmap     = 4,
+        allow_fb_mesh  = 4,
+        allow_lmap     = 8,
     } flags = Flags::none;
 
     float max_fov;
@@ -701,7 +701,7 @@ CallHook<int(const rf::NetAddr*, std::byte*, size_t)> send_join_accept_packet_ho
         if (server_allow_fullbright_meshes()) {
             ext_data.flags |= DashFactionJoinAcceptPacketExt::Flags::allow_fb_mesh;
         }
-        if (server_allow_disable_textures()) {
+        if (server_allow_lightmaps_only()) {
             ext_data.flags |= DashFactionJoinAcceptPacketExt::Flags::allow_lmap;
         }
         auto [new_data, new_len] = extend_packet(data, len, ext_data);

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -164,6 +164,14 @@ void load_additional_server_config(rf::Parser& parser)
         }
     }
 
+    if (parser.parse_optional("$DF Allow Fullbright Meshes:")) {
+        g_additional_server_config.allow_fullbright_meshes = parser.parse_bool();
+    }
+
+    if (parser.parse_optional("$DF Allow Disable Textures:")) {
+        g_additional_server_config.allow_disable_textures = parser.parse_bool();
+    }
+
     if (parser.parse_optional("$DF Send Player Stats Message:")) {
         g_additional_server_config.stats_message_enabled = parser.parse_bool();
     }
@@ -752,6 +760,16 @@ void server_on_limbo_state_enter()
 bool server_is_saving_enabled()
 {
     return g_additional_server_config.saving_enabled;
+}
+
+bool server_allow_fullbright_meshes()
+{
+    return g_additional_server_config.allow_fullbright_meshes;
+}
+
+bool server_allow_disable_textures()
+{
+    return g_additional_server_config.allow_disable_textures;
 }
 
 bool server_weapon_items_give_full_ammo()

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -168,8 +168,8 @@ void load_additional_server_config(rf::Parser& parser)
         g_additional_server_config.allow_fullbright_meshes = parser.parse_bool();
     }
 
-    if (parser.parse_optional("$DF Allow Disable Textures:")) {
-        g_additional_server_config.allow_disable_textures = parser.parse_bool();
+    if (parser.parse_optional("$DF Allow Lightmaps Only Mode:")) {
+        g_additional_server_config.allow_lightmaps_only = parser.parse_bool();
     }
 
     if (parser.parse_optional("$DF Send Player Stats Message:")) {
@@ -767,9 +767,9 @@ bool server_allow_fullbright_meshes()
     return g_additional_server_config.allow_fullbright_meshes;
 }
 
-bool server_allow_disable_textures()
+bool server_allow_lightmaps_only()
 {
-    return g_additional_server_config.allow_disable_textures;
+    return g_additional_server_config.allow_lightmaps_only;
 }
 
 bool server_weapon_items_give_full_ammo()

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -172,6 +172,10 @@ void load_additional_server_config(rf::Parser& parser)
         g_additional_server_config.allow_lightmaps_only = parser.parse_bool();
     }
 
+    if (parser.parse_optional("$DF Allow Disable Screenshake:")) {
+        g_additional_server_config.allow_disable_screenshake = parser.parse_bool();
+    }
+
     if (parser.parse_optional("$DF Send Player Stats Message:")) {
         g_additional_server_config.stats_message_enabled = parser.parse_bool();
     }
@@ -770,6 +774,11 @@ bool server_allow_fullbright_meshes()
 bool server_allow_lightmaps_only()
 {
     return g_additional_server_config.allow_lightmaps_only;
+}
+
+bool server_allow_disable_screenshake()
+{
+    return g_additional_server_config.allow_disable_screenshake;
 }
 
 bool server_weapon_items_give_full_ammo()

--- a/game_patch/multi/server.h
+++ b/game_patch/multi/server.h
@@ -11,6 +11,6 @@ void server_do_frame();
 bool check_server_chat_command(const char* msg, rf::Player* sender);
 bool server_is_saving_enabled();
 bool server_allow_fullbright_meshes();
-bool server_allow_disable_textures();
+bool server_allow_lightmaps_only();
 void server_reliable_socket_ready(rf::Player* player);
 bool server_weapon_items_give_full_ammo();

--- a/game_patch/multi/server.h
+++ b/game_patch/multi/server.h
@@ -12,5 +12,6 @@ bool check_server_chat_command(const char* msg, rf::Player* sender);
 bool server_is_saving_enabled();
 bool server_allow_fullbright_meshes();
 bool server_allow_lightmaps_only();
+bool server_allow_disable_screenshake();
 void server_reliable_socket_ready(rf::Player* player);
 bool server_weapon_items_give_full_ammo();

--- a/game_patch/multi/server.h
+++ b/game_patch/multi/server.h
@@ -10,5 +10,7 @@ void server_init();
 void server_do_frame();
 bool check_server_chat_command(const char* msg, rf::Player* sender);
 bool server_is_saving_enabled();
+bool server_allow_fullbright_meshes();
+bool server_allow_disable_textures();
 void server_reliable_socket_ready(rf::Player* player);
 bool server_weapon_items_give_full_ammo();

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -48,7 +48,7 @@ struct ServerAdditionalConfig
     std::optional<int> force_player_character;
     std::optional<float> max_fov;
     bool allow_fullbright_meshes = false;
-    bool allow_disable_textures = false;
+    bool allow_lightmaps_only = false;
     int anticheat_level = 0;
     bool stats_message_enabled = true;
     std::string welcome_message;

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -47,6 +47,8 @@ struct ServerAdditionalConfig
     bool upnp_enabled = true;
     std::optional<int> force_player_character;
     std::optional<float> max_fov;
+    bool allow_fullbright_meshes = false;
+    bool allow_disable_textures = false;
     int anticheat_level = 0;
     bool stats_message_enabled = true;
     std::string welcome_message;

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -49,6 +49,7 @@ struct ServerAdditionalConfig
     std::optional<float> max_fov;
     bool allow_fullbright_meshes = false;
     bool allow_lightmaps_only = false;
+    bool allow_disable_screenshake = false;
     int anticheat_level = 0;
     bool stats_message_enabled = true;
     std::string welcome_message;

--- a/game_patch/object/obj_light.cpp
+++ b/game_patch/object/obj_light.cpp
@@ -169,7 +169,7 @@ ConsoleCommand2 fullbright_models_cmd{
         rf::console::print("Fullbright meshes are {}", g_game_config.try_mesh_fullbright ?
 			"enabled. In multiplayer, this will only apply if the server allows it." : "disabled.");
     },
-    "Set all models to fullbright for visibility. In multiplayer, this is only available if the server allows it.",
+    "Set all meshes to render fullbright. In multiplayer, this is only available if the server allows it.",
 };
 
 void obj_light_apply_patch()

--- a/game_patch/object/obj_light.cpp
+++ b/game_patch/object/obj_light.cpp
@@ -97,7 +97,7 @@ FunHook<void()> obj_light_calculate_hook{
         rf::gr::view_matrix.make_identity();
         rf::gr::view_pos.zero();
         rf::gr::light_matrix.make_identity();
-        rf::gr::light_base.zero();      
+        rf::gr::light_base.zero();
 
         if (g_game_config.mesh_static_lighting) {
             // Enable static lights

--- a/game_patch/object/obj_light.cpp
+++ b/game_patch/object/obj_light.cpp
@@ -75,7 +75,7 @@ void evaluate_fullbright_meshes()
         rf::is_multi && !rf::is_server && get_df_server_info() && !get_df_server_info()->allow_fb_mesh;
 
     if (server_side_restrict_fb_mesh && g_game_config.try_mesh_fullbright) {
-        xlog::warn("This server does not allow you to force fullbright meshes!");
+        rf::console::print("This server does not allow you to force fullbright meshes!");
         return;
     }
 

--- a/game_patch/object/obj_light.cpp
+++ b/game_patch/object/obj_light.cpp
@@ -4,12 +4,14 @@
 #include <common/utils/list-utils.h>
 #include "../rf/object.h"
 #include "../rf/item.h"
+#include "../rf/level.h"
 #include "../rf/clutter.h"
 #include "../rf/gr/gr.h"
 #include "../rf/multi.h"
 #include "../rf/crt.h"
 #include "../os/console.h"
 #include "../main/main.h"
+#include "../multi/multi.h"
 
 void gr_light_use_static(bool use_static);
 
@@ -57,6 +59,34 @@ void obj_mesh_lighting_maybe_update(rf::Object *objp)
     }
 }
 
+void recalc_mesh_static_lighting()
+{
+    rf::obj_light_free();
+    rf::obj_light_alloc();
+    rf::obj_light_calculate();
+}
+
+void evaluate_fullbright_meshes()
+{
+    if (rf::LEVEL_LOADED) {
+        bool server_side_restrict_fb_mesh =
+            rf::is_multi && !rf::is_server && get_df_server_info() && !get_df_server_info().value().allow_fb_mesh;
+        if (server_side_restrict_fb_mesh && g_game_config.try_mesh_fullbright) {
+            xlog::warn("This server does not allow you to force fullbright meshes!");
+        }
+        else if (g_game_config.try_mesh_fullbright) {            
+            rf::gr::light_set_ambient(1.0f, 1.0f, 1.0f);
+            recalc_mesh_static_lighting();
+        }
+        else {
+            rf::gr::light_set_ambient(static_cast<float>(rf::level.ambient_light.red) / 255.0f,
+                                      static_cast<float>(rf::level.ambient_light.green) / 255.0f,
+                                      static_cast<float>(rf::level.ambient_light.blue) / 255.0f);
+            recalc_mesh_static_lighting();
+		}
+	}	
+}
+
 FunHook<void()> obj_light_calculate_hook{
     0x0048B0E0,
     []() {
@@ -65,7 +95,7 @@ FunHook<void()> obj_light_calculate_hook{
         rf::gr::view_matrix.make_identity();
         rf::gr::view_pos.zero();
         rf::gr::light_matrix.make_identity();
-        rf::gr::light_base.zero();
+        rf::gr::light_base.zero();      
 
         if (g_game_config.mesh_static_lighting) {
             // Enable static lights
@@ -115,13 +145,6 @@ FunHook<void()> obj_light_free_hook{
     },
 };
 
-void recalc_mesh_static_lighting()
-{
-    rf::obj_light_free();
-    rf::obj_light_alloc();
-    rf::obj_light_calculate();
-}
-
 ConsoleCommand2 mesh_static_lighting_cmd{
     "mesh_static_lighting",
     []() {
@@ -131,6 +154,20 @@ ConsoleCommand2 mesh_static_lighting_cmd{
         rf::console::print("Mesh static lighting is {}", g_game_config.mesh_static_lighting ? "enabled" : "disabled");
     },
     "Toggle mesh static lighting calculation",
+};
+
+ConsoleCommand2 fullbright_models_cmd{
+    "mesh_fullbright",
+    []() {
+        g_game_config.try_mesh_fullbright = !g_game_config.try_mesh_fullbright;
+        g_game_config.save();
+
+        evaluate_fullbright_meshes();    
+                
+        rf::console::print("Fullbright meshes are {}", g_game_config.try_mesh_fullbright ?
+			"enabled. In multiplayer, this will only apply if the server allows it." : "disabled.");
+    },
+    "Set all models to fullbright for visibility. In multiplayer, this is only available if the server allows it.",
 };
 
 void obj_light_apply_patch()
@@ -145,4 +182,5 @@ void obj_light_apply_patch()
 
     // Commands
     mesh_static_lighting_cmd.register_cmd();
+    fullbright_models_cmd.register_cmd();
 }

--- a/game_patch/object/obj_light.cpp
+++ b/game_patch/object/obj_light.cpp
@@ -68,23 +68,25 @@ void recalc_mesh_static_lighting()
 
 void evaluate_fullbright_meshes()
 {
-    if (rf::LEVEL_LOADED) {
-        bool server_side_restrict_fb_mesh =
-            rf::is_multi && !rf::is_server && get_df_server_info() && !get_df_server_info().value().allow_fb_mesh;
-        if (server_side_restrict_fb_mesh && g_game_config.try_mesh_fullbright) {
-            xlog::warn("This server does not allow you to force fullbright meshes!");
-        }
-        else if (g_game_config.try_mesh_fullbright) {            
-            rf::gr::light_set_ambient(1.0f, 1.0f, 1.0f);
-            recalc_mesh_static_lighting();
-        }
-        else {
-            rf::gr::light_set_ambient(static_cast<float>(rf::level.ambient_light.red) / 255.0f,
-                                      static_cast<float>(rf::level.ambient_light.green) / 255.0f,
-                                      static_cast<float>(rf::level.ambient_light.blue) / 255.0f);
-            recalc_mesh_static_lighting();
-		}
-	}	
+    if (!rf::LEVEL_LOADED)
+        return;
+
+    bool server_side_restrict_fb_mesh =
+        rf::is_multi && !rf::is_server && get_df_server_info() && !get_df_server_info()->allow_fb_mesh;
+
+    if (server_side_restrict_fb_mesh && g_game_config.try_mesh_fullbright) {
+        xlog::warn("This server does not allow you to force fullbright meshes!");
+        return;
+    }
+
+    auto [r, g, b] = g_game_config.try_mesh_fullbright
+                         ? std::make_tuple(1.0f, 1.0f, 1.0f)
+                         : std::make_tuple(static_cast<float>(rf::level.ambient_light.red) / 255.0f,
+                                           static_cast<float>(rf::level.ambient_light.green) / 255.0f,
+                                           static_cast<float>(rf::level.ambient_light.blue) / 255.0f);
+
+    rf::gr::light_set_ambient(r, g, b);
+    recalc_mesh_static_lighting();
 }
 
 FunHook<void()> obj_light_calculate_hook{

--- a/game_patch/rf/gr/gr.h
+++ b/game_patch/rf/gr/gr.h
@@ -348,6 +348,9 @@ namespace rf::gr
     static auto& start_instance = addr_as_ref<void(const Vector3& pos, const Matrix3& orient)>(0x00517F00);
     static auto& stop_instance = addr_as_ref<void()>(0x00517F20);
     static auto& project_vertex = addr_as_ref<ubyte (Vertex *p)>(0x00518440);
+    static auto& bm_set_resolution_level_for_all = addr_as_ref<void(int level)>(0x0050EF10);
+    static auto& show_lightmaps = *reinterpret_cast<bool*>(0x009BB5A4);
+    static auto& light_set_ambient = addr_as_ref<void(float r, float g, float b)>(0x004D8CE0);
 
     inline void set_color(ubyte r, ubyte g, ubyte b, ubyte a = screen.current_color.alpha)
     {

--- a/game_patch/rf/gr/gr.h
+++ b/game_patch/rf/gr/gr.h
@@ -348,7 +348,6 @@ namespace rf::gr
     static auto& start_instance = addr_as_ref<void(const Vector3& pos, const Matrix3& orient)>(0x00517F00);
     static auto& stop_instance = addr_as_ref<void()>(0x00517F20);
     static auto& project_vertex = addr_as_ref<ubyte (Vertex *p)>(0x00518440);
-    static auto& bm_set_resolution_level_for_all = addr_as_ref<void(int level)>(0x0050EF10);
     static auto& show_lightmaps = *reinterpret_cast<bool*>(0x009BB5A4);
     static auto& light_set_ambient = addr_as_ref<void(float r, float g, float b)>(0x004D8CE0);
 


### PR DESCRIPTION
This PR adds:
- 3 console commands: `lightmaps_only`, `mesh_fullbright`, and `disable_screenshake` (all default to false)
- 3 corresponding dedicated server config options: `$DF Allow Fullbright Meshes`, `$DF Allow Lightmaps Only Mode`, and `$DF Allow Disable Screenshake` (all default to false)

Explanation of features:
- `lightmaps_only`: Render levels in lightmap only mode, providing enhanced visibility.
- `mesh_fullbright`: Render all meshes fullbright (255, 255, 255). This is in effect the same as the mapping design choice commonly referred to as the "lighting trick", though unlike that approach, does not require a new version of the map to exist. The practice of mappers "applying the lighting trick" can be sunset by the existence of this feature, meaning mappers can make artistic choices in their competitively-designed levels that are impossible today, while the highly important capability still exists for competitive players to use.
- `disable_screenshake`: Disable all use of screenshake. Most noticeable is when firing the SMG and Assault Rifle.

In essence, the concept behind this change is that clients can "desire" these options apply. If so, they will apply in single player, in listen servers hosted by that player, and in any multiplayer servers where the server operator has explicitly allowed use of that option via the new dedicated server config options. They will however NOT apply in any servers where they have not been explicitly allowed. This approach allows clients to decide to use these enhanced visibility options if they so choose, assuming the server "approves" of it, similar to how server operators can already decide the maximum horizontal FOV allowed for players in their server.

Notably, these options will be treated as false (ie. players cannot use these options) in any servers that either do not explicitly allow them, and any servers running older versions of Dash from before the options existed. This means that there is no relevant risk of clients using these features to "cheat".

Resolves #111 
Resolves #182 