### PR TITLE
Fix crash when verify_level is run from main menu

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@ Version 1.9.0 (not released yet)
 - Do not load unnecessary VPPs in dedicated server mode
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
+- Fix crash when `verify_level` command is run without a level being loaded
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------


### PR DESCRIPTION
This PR adds a check of whether a level is currently loaded before allowing the `verify_level` command to execute. Without this PR, the game crashes if this command is run without a level being loaded.

Resolves #253 