### PR TITLE
Alias spectate command to camera2 in SP, add help strings for cheat commands

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,8 @@ Version 1.9.0 (not released yet)
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
 - Fix crash when `verify_level` command is run without a level being loaded
+- Add missing help strings for builtin cheat commands
+- Make `spectate` command set camera to free look when issued in single player
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/hud/multi_spectate.cpp
+++ b/game_patch/hud/multi_spectate.cpp
@@ -3,6 +3,7 @@
 #include "multi_scoreboard.h"
 #include "../os/console.h"
 #include "../rf/entity.h"
+#include "../rf/level.h"
 #include "../rf/player/player.h"
 #include "../rf/multi.h"
 #include "../rf/gameseq.h"
@@ -229,8 +230,15 @@ FunHook<void(rf::Player*)> render_reticle_hook{
 ConsoleCommand2 spectate_cmd{
     "spectate",
     [](std::optional<std::string> player_name) {
+        if (!(rf::level.flags & rf::LEVEL_LOADED)) {
+            rf::console::output("No level loaded!", nullptr);
+            return;
+        }
+
         if (!rf::is_multi) {
-            rf::console::output("Spectate mode is only supported in multiplayer game!", nullptr);
+            // in single player, just enter free look mode
+            rf::console::output("Camera mode set to free look. Use `camera1` to return to first person.", nullptr);
+            rf::camera_enter_freelook(rf::local_player->cam);
             return;
         }
 

--- a/game_patch/os/commands.cpp
+++ b/game_patch/os/commands.cpp
@@ -107,30 +107,26 @@ FunHook<void()> verify_level_cmd_hook{
     }
 };
 
-bool check_can_use_cheat_cmd()
-{
-    return (rf::level.flags & rf::LEVEL_LOADED) && !rf::is_multi;
-}
-
 void handle_camera_command(FunHook<void()>& hook)
 {
-    if (!check_can_use_cheat_cmd()) {
-        if (!(rf::level.flags & rf::LEVEL_LOADED)) {
-            rf::console::print("No level loaded!");
-        }
-        else if (rf::is_multi) {
-            rf::console::print("That command can't be used in multiplayer.");
-        }
+    if (!(rf::level.flags & rf::LEVEL_LOADED)) {
+        rf::console::print("No level loaded!");
         return;
     }
+
+    if (rf::is_multi) {
+        rf::console::print("That command can't be used in multiplayer.");
+        return;
+    }
+
     hook.call_target();
 
     const rf::CameraMode current_mode = rf::camera_get_mode(*rf::local_player->cam);
 
-    std::string mode_text = (current_mode == rf::CAMERA_FIRST_PERSON)          ? "first person"
-                            : (current_mode == rf::CAMERA_THIRD_PERSON)    ? "third person"
+    std::string mode_text = (current_mode == rf::CAMERA_FIRST_PERSON)   ? "first person"
+                            : (current_mode == rf::CAMERA_THIRD_PERSON) ? "third person"
                             : (current_mode == rf::CAMERA_FREELOOK)     ? "free look"
-                                                                               : "unknown";
+                                                                        : "unknown";
 
     std::string helper_text =
         (current_mode == rf::CAMERA_FIRST_PERSON) ? "" : " Use `camera1` to return to first person.";
@@ -145,15 +141,16 @@ FunHook<void()> camera3_cmd_hook{0x00431330, []() { handle_camera_command(camera
 FunHook<void()> heehoo_cmd_hook{
     0x00431210,
     []() {
-    if (!check_can_use_cheat_cmd()) {
-        if (!(rf::level.flags & rf::LEVEL_LOADED)) {
-            rf::console::print("No level loaded!");
-        }
-        else if (rf::is_multi) {
-            rf::console::print("That command can't be used in multiplayer.");
-        }
+    if (!(rf::level.flags & rf::LEVEL_LOADED)) {
+        rf::console::print("No level loaded!");
         return;
     }
+
+    if (rf::is_multi) {
+        rf::console::print("That command can't be used in multiplayer.");
+        return;
+    }
+
     if (rf::entity_is_flying(rf::local_player_entity)) {
         rf::hud_msg("You feel heavy", 0, 0, 0);
     } else {

--- a/game_patch/os/commands.cpp
+++ b/game_patch/os/commands.cpp
@@ -125,7 +125,7 @@ void handle_camera_command(FunHook<void()>& hook)
     }
     hook.call_target();
 
-    rf::CameraMode current_mode = rf::camera_get_mode(rf::local_player->cam);
+    const rf::CameraMode current_mode = rf::camera_get_mode(*rf::local_player->cam);
 
     std::string mode_text = (current_mode == rf::CAMERA_FIRST_PERSON)          ? "first person"
                             : (current_mode == rf::CAMERA_THIRD_PERSON)    ? "third person"

--- a/game_patch/rf/entity.h
+++ b/game_patch/rf/entity.h
@@ -414,6 +414,7 @@ namespace rf
     static auto& entity_fire_init_bones = addr_as_ref<bool(EntityFireInfo *efi, Object *objp)>(0x0042EB20);
     static auto& entity_is_swimming = addr_as_ref<bool(Entity* ep)>(0x0042A0A0);
     static auto& entity_is_falling = addr_as_ref<bool(Entity* ep)>(0x0042A020);
+    static auto& entity_is_flying = addr_as_ref<bool(Entity* ep)>(0x0042A060);
     static auto& entity_can_swim = addr_as_ref<bool(Entity* ep)>(0x00427FF0);
     static auto& entity_update_liquid_status = addr_as_ref<void(Entity* ep)>(0x00429100);
     static auto& entity_is_playing_action_animation = addr_as_ref<bool(Entity* entity, int action)>(0x00428D10);

--- a/game_patch/rf/hud.h
+++ b/game_patch/rf/hud.h
@@ -144,4 +144,5 @@ namespace rf
     static auto& hud_weapon_cycle_current_idx = addr_as_ref<int>(0x007C71A8);
 
     static auto& hud_do_frame = addr_as_ref<void(Player*)>(0x00437B80);
+    static auto& hud_msg = addr_as_ref<void(const char* text, int, int duration, Color*)>(0x004383C0);
 }

--- a/game_patch/rf/player/camera.h
+++ b/game_patch/rf/player/camera.h
@@ -45,4 +45,6 @@ namespace rf
         AddrCaller{0x0040D780}.c_call(&result, camera);
         return result;
     }
+
+    static auto& camera_get_mode = addr_as_ref<CameraMode(rf::Camera*)>(0x0040D740);
 }

--- a/game_patch/rf/player/camera.h
+++ b/game_patch/rf/player/camera.h
@@ -46,5 +46,5 @@ namespace rf
         return result;
     }
 
-    static auto& camera_get_mode = addr_as_ref<CameraMode(rf::Camera*)>(0x0040D740);
+    static auto& camera_get_mode = addr_as_ref<CameraMode(const rf::Camera&)>(0x0040D740);
 }


### PR DESCRIPTION
This PR:
- Makes `spectate` set the camera to free look (same as `camera2`) when issued in single player (as opposed to just kicking back an error)
- Adds missing help strings to the `camera1`, `camera2`, `camera3`, and `heehoo` builtin cheat commands. In the case of `heehoo`, this is displayed using `hud_msg` just like `vivalahelvig` and `bighugmug`. For the `cameraX` commands, the help text is printed to the console so that when a player wants to go back to first person, they'll know how.

Resolves #206 