### PR TITLE
Add command to allow adding/changing/removing server password

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@ Version 1.9.0 (not released yet)
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
 - Fix crash when `verify_level` command is run without a level being loaded
+- Add `server_password` command
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -33,6 +33,7 @@
 const char* g_rcon_cmd_whitelist[] = {
     "kick",
     "level",
+    "server_password",
     "map",
     "ban",
     "ban_ip",

--- a/game_patch/os/commands.cpp
+++ b/game_patch/os/commands.cpp
@@ -92,6 +92,27 @@ DcCommandAlias map_info_cmd{
     level_info_cmd,
 };
 
+ConsoleCommand2 server_password_cmd{
+    "server_password",
+    [](std::optional<std::string> pattern) {
+        if (!rf::is_multi || !rf::is_server) {
+            rf::console::print("This command can only be run as a server!");
+            return;
+        }            
+
+        if (pattern) {
+            rf::netgame.password = pattern.value().c_str();
+            rf::console::print("Server password set to: {}", *pattern);
+        }
+        else {
+            rf::netgame.password = "";
+            rf::console::print("Server password removed.");
+        }
+    },
+    "Set or remove the server password.",
+    "server_password <password>",
+};
+
 // only allow verify_level if a level is loaded (avoid a crash if command is run in menu)
 FunHook<void()> verify_level_cmd_hook{
     0x0045E1F0,
@@ -205,5 +226,6 @@ void console_commands_init()
     map_cmd.register_cmd();
     level_info_cmd.register_cmd();
     map_info_cmd.register_cmd();
+    server_password_cmd.register_cmd();
     verify_level_cmd_hook.install();
 }

--- a/game_patch/os/commands.cpp
+++ b/game_patch/os/commands.cpp
@@ -94,15 +94,15 @@ DcCommandAlias map_info_cmd{
 
 ConsoleCommand2 server_password_cmd{
     "server_password",
-    [](std::optional<std::string> pattern) {
+    [](std::optional<std::string> new_password) {
         if (!rf::is_multi || !rf::is_server) {
             rf::console::print("This command can only be run as a server!");
             return;
         }            
 
-        if (pattern) {
-            rf::netgame.password = pattern.value().c_str();
-            rf::console::print("Server password set to: {}", *pattern);
+        if (new_password) {
+            rf::netgame.password = new_password.value().c_str();
+            rf::console::print("Server password set to: {}", rf::netgame.password);
         }
         else {
             rf::netgame.password = "";


### PR DESCRIPTION
This PR adds the `server_password` command, which can be used either as server or via rcon to add a password to a server without one, change the existing password to something else, or remove the password entirely.

Syntax is `server_password <password>`

Resolves #125 