### PR TITLE
Add command to allow adding/changing/removing rcon password

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@ Version 1.9.0 (not released yet)
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
 - Fix crash when `verify_level` command is run without a level being loaded
+- Add `server_rcon_password` command
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/os/commands.cpp
+++ b/game_patch/os/commands.cpp
@@ -92,6 +92,35 @@ DcCommandAlias map_info_cmd{
     level_info_cmd,
 };
 
+ConsoleCommand2 server_rcon_password_cmd{
+    "server_rcon_password",
+    [](std::optional<std::string> pattern) {
+        if (!rf::is_multi || !rf::is_server) {
+            rf::console::print("This command can only be run as a server!");
+            return;
+        }
+        rf::console::print("Current rcon password is: {}", rf::rcon_password);
+
+        if (pattern) {
+            if (pattern->size() > 16) {
+                // game limits client requests to 16 characters
+                rf::console::print("Server rcon password cannot exceed 16 characters.");
+                return;
+            }
+
+            std::strncpy(rf::rcon_password, pattern->c_str(), sizeof(rf::rcon_password) - 1);
+            rf::rcon_password[sizeof(rf::rcon_password) - 1] = '\0'; // null terminator
+            rf::console::print("Server rcon password set to: {}", *pattern);
+        }
+        else {
+            std::memset(rf::rcon_password, 0, sizeof(rf::rcon_password));
+            rf::console::print("Server rcon password removed.");
+        }
+    },
+    "Set or remove the server rcon password.",
+    "server_rcon_password <password>",
+};
+
 // only allow verify_level if a level is loaded (avoid a crash if command is run in menu)
 FunHook<void()> verify_level_cmd_hook{
     0x0045E1F0,
@@ -205,5 +234,6 @@ void console_commands_init()
     map_cmd.register_cmd();
     level_info_cmd.register_cmd();
     map_info_cmd.register_cmd();
+    server_rcon_password_cmd.register_cmd();
     verify_level_cmd_hook.install();
 }

--- a/game_patch/rf/multi.h
+++ b/game_patch/rf/multi.h
@@ -174,6 +174,7 @@ namespace rf
     static auto& is_dedicated_server = addr_as_ref<bool>(0x0064ECBB);
     static auto& simultaneous_ping = addr_as_ref<uint32_t>(0x00599CD8);
     static auto& tracker_addr = addr_as_ref<NetAddr>(0x006FC550);
+    static auto& rcon_password = *reinterpret_cast<char (*)[0x14]>(0x0064ECD0); // max 20 characters
 
     enum ChatSayType {
         CHAT_SAY_GLOBAL = 0,


### PR DESCRIPTION
This PR adds the `server_rcon_password` command, which can be used to add an rcon password to a server without one, change the existing rcon password to something else, or remove the rcon password entirely.

Syntax is `server_rcon_password <password>`