### PR TITLE
Make players maintain relative velocity when teleporting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@ Version 1.9.0 (not released yet)
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
 - Fix crash when `verify_level` command is run without a level being loaded
+- Make player maintain relative velocity when teleporting
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/rf/entity.h
+++ b/game_patch/rf/entity.h
@@ -414,6 +414,7 @@ namespace rf
     static auto& entity_fire_init_bones = addr_as_ref<bool(EntityFireInfo *efi, Object *objp)>(0x0042EB20);
     static auto& entity_is_swimming = addr_as_ref<bool(Entity* ep)>(0x0042A0A0);
     static auto& entity_is_falling = addr_as_ref<bool(Entity* ep)>(0x0042A020);
+    static auto& entity_on_ground = addr_as_ref<bool(Entity* ep)>(0x0042A0D0);
     static auto& entity_can_swim = addr_as_ref<bool(Entity* ep)>(0x00427FF0);
     static auto& entity_update_liquid_status = addr_as_ref<void(Entity* ep)>(0x00429100);
     static auto& entity_is_playing_action_animation = addr_as_ref<bool(Entity* entity, int action)>(0x00428D10);
@@ -425,6 +426,7 @@ namespace rf
     static auto& entity_turn_weapon_on = addr_as_ref<void __cdecl(int entity_handle, int weapon_type, bool alt_fire)>(0x0041A870);
     static auto& entity_turn_weapon_off = addr_as_ref<void __cdecl(int entity_handle, int weapon_type)>(0x0041AE70);
     static auto& entity_restore_mesh = addr_as_ref<void(Entity *ep, const char *mesh_name)>(0x0042C570);
+    static auto& entity_detach_from_host = addr_as_ref<void(Entity* ep)>(0x004279D0);
 
     static auto& entity_list = addr_as_ref<Entity>(0x005CB060);
     static auto& local_player_entity = addr_as_ref<Entity*>(0x005CB054);

--- a/game_patch/rf/object.h
+++ b/game_patch/rf/object.h
@@ -132,6 +132,7 @@ namespace rf
     static auto& obj_light_free = addr_as_ref<void()>(0x0048B370);
     static auto& obj_light_alloc = addr_as_ref<void()>(0x0048B1D0);
     static auto& obj_light_calculate = addr_as_ref<void()>(0x0048B0E0);
+    static auto& physics_force_to_ground = addr_as_ref<void(Object* obj)>(0x004A0770);
 
     static auto& object_list = addr_as_ref<Object>(0x0073D880);
 }


### PR DESCRIPTION
This PR adjusts the behaviour of the `Teleport_Player` event such that relative velocity is maintained when teleporting. This means that when you go into a teleporter, you come out of the teleporter going the same speed, regardless of the direction of the teleport destination relative to the teleport entrance.

Functionally this vastly improves the experience when teleporting - you no longer run into a teleporter and come out flying sideways or something.

Resolves #19 

This PR also makes two other much more minor adjustments which I'll note just for the record:
- Attempts to put the player on the ground when they teleport if they were on the ground before. The base game already did this but it was turned off for multiplayer clients before this PR. Should in theory make some teleports in multiplayer a bit smoother.
- Makes the hackfix Volition implemented in `L20S2.rfl` (which teleports your vehicle instead of dumping you out of the vehicle like is normally the case) more specific - base game only checked the level filename when deciding whether to apply the hackfix, after this PR it also checks the event UID. This is very, very minor, but it is safer to do it this way just to avoid any potential unexpected behaviour in mods that modify this level.