### PR TITLE
Add overtime when round ends in a tie

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ Configuration example:
     +Health Is Super:
     // Limit armor reward to 200 instead of 100
     +Armor Is Super:
+    // Enable for round to go to overtime when the time limit is up but score is tied
+    $DF Overtime Enabled: false
+        // Overtime ends when tie is broken or after this duration (whichever comes first)
+        +Duration: 5
 
 
 Building

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@ Version 1.9.0 (not released yet)
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
 - Fix crash when `verify_level` command is run without a level being loaded
+- Add `$DF Overtime Enabled` option in dedicated server config
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -676,13 +676,20 @@ bool round_is_tied(rf::NetGameType game_type)
 
     switch (game_type) {
     case rf::NG_TYPE_DM: {
-        int first_player_score = rf::player_list->stats->score;
-        for (rf::Player* player = rf::player_list->next; player != rf::player_list; player = player->next) {
-            if (player->stats->score != first_player_score) {
-                return false;
+        int highest_score = rf::player_list->stats->score;
+        int players_with_highest_score = 1;
+
+        for (rf::Player* player = rf::player_list->next; player != nullptr &&
+            player != rf::player_list; player = player->next) {        
+            if (player->stats->score > highest_score) {
+                highest_score = player->stats->score;
+                players_with_highest_score = 1;
+            }
+            else if (player->stats->score == highest_score) {
+                players_with_highest_score++;
             }
         }
-        return true;
+        return players_with_highest_score >= 2;
     }
     case rf::NG_TYPE_CTF: {
         int red_score = rf::multi_ctf_get_red_team_score();

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -20,6 +20,7 @@
 #include "../main/main.h"
 #include <common/utils/list-utils.h>
 #include "../rf/player/player.h"
+#include "../rf/gameseq.h"
 #include "../rf/multi.h"
 #include "../rf/parse.h"
 #include "../rf/weapon.h"
@@ -44,6 +45,7 @@ const char* g_rcon_cmd_whitelist[] = {
 
 ServerAdditionalConfig g_additional_server_config;
 std::string g_prev_level;
+bool g_is_overtime = false;
 
 void parse_vote_config(const char* vote_name, VoteConfig& config, rf::Parser& parser)
 {
@@ -189,6 +191,13 @@ void load_additional_server_config(rf::Parser& parser)
         }
         if (parser.parse_optional("+Armor Is Super:")) {
             g_additional_server_config.kill_reward_armor_super = {parser.parse_bool()};
+        }
+    }
+
+    if (parser.parse_optional("$DF Overtime Enabled:")) {
+        g_additional_server_config.overtime.enabled = parser.parse_bool();
+        if (parser.parse_optional("+Duration:")) {
+            g_additional_server_config.overtime.additional_time = parser.parse_uint();
         }
     }
 
@@ -659,6 +668,104 @@ CodeInjection multi_limbo_init_injection{
     },
 };
 
+bool round_is_tied(rf::NetGameType game_type)
+{
+    if (rf::multi_num_players() <= 1) {
+        return false;
+    }
+
+    switch (game_type) {
+    case rf::NG_TYPE_DM: {
+        int first_player_score = rf::player_list->stats->score;
+        for (rf::Player* player = rf::player_list->next; player != rf::player_list; player = player->next) {
+            if (player->stats->score != first_player_score) {
+                return false;
+            }
+        }
+        return true;
+    }
+    case rf::NG_TYPE_CTF: {
+        int red_score = rf::multi_ctf_get_red_team_score();
+        int blue_score = rf::multi_ctf_get_blue_team_score();
+
+        if (red_score == blue_score) {
+            return true;
+        }
+
+        bool red_flag_stolen = !rf::multi_ctf_is_red_flag_in_base();
+        bool blue_flag_stolen = !rf::multi_ctf_is_blue_flag_in_base();
+
+        // not currently tied, but if the team with the flag right now caps it, they will be
+        return (red_flag_stolen && blue_score == red_score - 1) || (blue_flag_stolen && red_score == blue_score - 1);
+    }
+    case rf::NG_TYPE_TEAMDM: {
+        return rf::multi_tdm_get_red_team_score() == rf::multi_tdm_get_blue_team_score();
+    }
+    default:
+        return false;
+    }
+}
+
+FunHook<void()> multi_check_for_round_end_hook{
+    0x0046E7C0,
+    []() {
+        const bool time_up = (rf::multi_time_limit > 0.0f && rf::level.time >= rf::multi_time_limit);
+        bool round_over = time_up;
+        const auto game_type = rf::multi_get_game_type();
+
+        if (g_is_overtime) {
+            round_over = (time_up || !round_is_tied(game_type));
+        }
+        else {
+            switch (game_type) {
+            case rf::NG_TYPE_DM: {
+                for (rf::Player* player = rf::player_list; player; player = player->next) {
+                    if (player->stats->score >= rf::multi_kill_limit) {
+                        round_over = true;
+                        break;
+                    }
+                    if (player == rf::player_list)
+                        break;
+                }
+                break;
+            }
+            case rf::NG_TYPE_CTF: {
+                if (rf::multi_ctf_get_red_team_score() >= rf::multi_cap_limit ||
+                    rf::multi_ctf_get_blue_team_score() >= rf::multi_cap_limit) {
+                    round_over = true;
+                }
+                break;
+            }
+            case rf::NG_TYPE_TEAMDM: {
+                if (rf::multi_tdm_get_red_team_score() >= rf::multi_kill_limit ||
+                    rf::multi_tdm_get_blue_team_score() >= rf::multi_kill_limit) {
+                    round_over = true;
+                }
+                break;
+            }
+            default:
+                break;
+            }
+        }
+
+        if (round_over && rf::gameseq_get_state() != rf::GS_MULTI_LIMBO) {
+            if (time_up && g_additional_server_config.overtime.enabled && !g_is_overtime && round_is_tied(game_type)) {
+                g_is_overtime = true;
+                extend_round_time(g_additional_server_config.overtime.additional_time);
+
+                std::string msg = std::format("\xA6 OVERTIME! Game will end when the tie is broken");
+                msg += g_additional_server_config.overtime.additional_time > 0
+                           ? std::format(", or in {} minutes!", g_additional_server_config.overtime.additional_time)
+                           : "!";
+                send_chat_line_packet(msg.c_str(), nullptr);
+            }
+            else {
+                rf::multi_change_level(nullptr);
+            }
+        }
+    }
+};
+
 void server_init()
 {
     // Override rcon command whitelist
@@ -724,6 +831,9 @@ void server_init()
 
     // Reduce limbo duration if server is empty
     multi_limbo_init_injection.install();
+
+    // Check if round is finished or if overtime should begin
+    multi_check_for_round_end_hook.install();
 }
 
 void server_do_frame()
@@ -734,6 +844,7 @@ void server_do_frame()
 
 void server_on_limbo_state_enter()
 {
+    g_is_overtime = false;
     g_prev_level = rf::level.filename.c_str();
     server_vote_on_limbo_state_enter();
 

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -26,6 +26,12 @@ struct HitSoundsConfig
     int rate_limit = 10;
 };
 
+struct OvertimeConfig
+{
+    bool enabled = false;
+    int additional_time = 5;
+};
+
 struct ServerAdditionalConfig
 {
     VoteConfig vote_kick;
@@ -38,6 +44,7 @@ struct ServerAdditionalConfig
     std::optional<float> spawn_life;
     std::optional<float> spawn_armor;
     HitSoundsConfig hit_sounds;
+    OvertimeConfig overtime;
     std::map<std::string, std::string> item_replacements;
     std::string default_player_weapon;
     std::optional<int> default_player_weapon_ammo;

--- a/game_patch/rf/multi.h
+++ b/game_patch/rf/multi.h
@@ -142,6 +142,9 @@ namespace rf
     static auto& multi_io_send_buffered_reliable_packets = addr_as_ref<void(Player *pp)>(0x004796C0);
     static auto& multi_find_player_by_addr = addr_as_ref<Player*(const NetAddr& addr)>(0x00484850);
     static auto& multi_find_player_by_id = addr_as_ref<Player*(uint8_t id)>(0x00484890);
+    static auto& multi_time_limit = addr_as_ref<float>(0x0064EC4C);
+    static auto& multi_kill_limit = addr_as_ref<int>(0x0064EC50);
+    static auto& multi_cap_limit = addr_as_ref<int>(0x0064EC58);
     static auto& multi_ctf_get_red_team_score = addr_as_ref<uint8_t()>(0x00475020);
     static auto& multi_ctf_get_blue_team_score = addr_as_ref<uint8_t()>(0x00475030);
     static auto& multi_ctf_get_red_flag_player = addr_as_ref<Player*()>(0x00474E60);


### PR DESCRIPTION
This PR adds sudden death overtime as an optional feature for server operators. If enabled, when the time limit is reached, if the score is a tie, some additional time (configurable) will be added and the game will end either when that additional time has elapsed, or the tie is broken (whichever comes first).

Configuration of the feature in dedicated_server.txt is as follows (default values shown):
```
    $DF Overtime Enabled: false
        +Duration: 5
```

"Ties" for the purpose of overtime are defined as:
- DM: At least 2 players are tied for the highest score.
- TDM: Red and blue have the same score.
- CTF: Red and blue have the same number of captures OR the delta is 1, and a flag is currently stolen which, if captured, would tie the game. 

(in the case of CTF, if the game is tied because a flag is stolen and would tie the game if captured, the tie is broken if that flag is returned)

A few other minor points:
- I had to reimplement most of `multi_check_for_round_end_hook` to support overtime either way, but I also took the opportunity to restructure the code using modern C++ methods as opposed to the stock game implementation.
- Unlike the stock code, my new code no longer continually attempts to initiate a level change every frame after the round ends. In theory this _should_ be a performance improvement but I've not attempted to measure it or anything.