### PR TITLE
Scale geomod crater texture PPM based on its resolution

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@ Version 1.9.0 (not released yet)
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
 - Fix crash when `verify_level` command is run without a level being loaded
+- Add correct scaling for geomod crater texture based on resolution
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/bmpman/bmpman.h
+++ b/game_patch/bmpman/bmpman.h
@@ -4,6 +4,13 @@
 #include "../rf/bmpman.h"
 #include "../rf/gr/gr.h"
 
+namespace rf
+{
+    static auto& bm_bitmaps = addr_as_ref<void*>(0x017C80C4);
+    static auto& bm_get_cache_slot = addr_as_ref<int(int)>(0x0050F440);
+    static auto& geomod_crater_texture_handle = addr_as_ref<int>(0x00646000);
+}
+
 void bm_set_dynamic(int bm_handle, bool dynamic);
 bool bm_is_dynamic(int bm_handle);
 void bm_change_format(int bm_handle, rf::bm::Format format);


### PR DESCRIPTION
This PR adjusts the pixels per metre (PPM) value applied to geomod craters at creation such that it scales based on the resolution of the crater texture. Base game behaviour is to use a static PPM value of 32.0.

This is beneficial because custom geomod textures (either via HD texture mods or configuration by level author in Level Properties) will now display correctly. Stock game behaviour stretches them out if their resolution is >256. The new behaviour in this PR scales them based on the game's established standard of 32 PPM at 256px resolution. As a result, this PR has _no_ effect whatsoever unless you either have a clientside mod that replaces `rock02.tga` or you load a map configured to not use the default geomod crater texture.

Resolves #69 

Here are some screenshots showing the behaviour with this PR:

**256x256 crater texture (default)**
![20241020_004241_glass_house](https://github.com/user-attachments/assets/f6a89b12-ce8d-4a13-900d-0d3210bbf72b)

**512x512 crater texture**
![20241020_004159_glass_house](https://github.com/user-attachments/assets/04fb24df-844c-43c6-9e76-39c6f0ca6772)

**8192x8192 crater texture**
![20241020_004040_glass_house](https://github.com/user-attachments/assets/39cac5bf-45ba-4f9e-923d-b33a86399102)