### PR TITLE
Adjust spawn protection dedicated server option to allow use of invuln powerup

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,12 @@ Configuration example:
     $DF Vote Next: true
     // Enable vote previous
     $DF Vote Previous: true
-    // Duration of player invulnerability after respawn in ms (default is the same as in stock RF - 1500)
-    $DF Spawn Protection Duration: 1500
+    // Determine whether players are granted some duration of invulnerability after spawning (stock RF is true)
+    $DF Spawn Protection Enabled: true
+        // Duration of the invulnerability in ms (stock RF is 1500)
+        +Duration: 1500
+        // Enable to use an Invulnerability powerup for the spawn protection (intended for run servers)
+        +Use Powerup: false
     // Initial player life (health) after spawn
     $DF Spawn Health: 100
     // Initial player armor after spawn

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@ Version 1.9.0 (not released yet)
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
 - Fix crash when `verify_level` command is run without a level being loaded
+- Change spawn protection option in dedicated server config to allow it to use Invulnerability powerup
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -74,8 +74,15 @@ void load_additional_server_config(rf::Parser& parser)
     parse_vote_config("Vote Restart", g_additional_server_config.vote_restart, parser);
     parse_vote_config("Vote Next", g_additional_server_config.vote_next, parser);
     parse_vote_config("Vote Previous", g_additional_server_config.vote_previous, parser);
-    if (parser.parse_optional("$DF Spawn Protection Duration:")) {
-        g_additional_server_config.spawn_protection_duration_ms = parser.parse_uint();
+
+    if (parser.parse_optional("$DF Spawn Protection Enabled:")) {
+        g_additional_server_config.spawn_protection.enabled = parser.parse_bool();
+        if (parser.parse_optional("+Duration:")) {
+            g_additional_server_config.spawn_protection.duration = parser.parse_uint();
+        }
+        if (parser.parse_optional("+Use Powerup:")) {
+            g_additional_server_config.spawn_protection.use_powerup = parser.parse_bool();
+        }
     }
 
     if (parser.parse_optional("$DF Spawn Health:")) {
@@ -353,7 +360,16 @@ bool check_server_chat_command(const char* msg, rf::Player* sender)
 CodeInjection spawn_protection_duration_patch{
     0x0048089A,
     [](auto& regs) {
-        *static_cast<int*>(regs.esp) = g_additional_server_config.spawn_protection_duration_ms;
+        if (g_additional_server_config.spawn_protection.enabled) {
+            if (g_additional_server_config.spawn_protection.use_powerup) {
+                rf::Player* pp = regs.esi;
+                rf::multi_powerup_add(pp, 0, g_additional_server_config.spawn_protection.duration);
+                return;
+            }
+        }
+        *static_cast<int*>(regs.esp) = g_additional_server_config.spawn_protection.enabled
+			? g_additional_server_config.spawn_protection.duration
+			: 0;
     },
 };
 

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -11,6 +11,13 @@ namespace rf
     struct Player;
 }
 
+struct SpawnProtectionConfig
+{
+    bool enabled = true;
+    int duration = 1500;
+    bool use_powerup = false;
+};
+
 struct VoteConfig
 {
     bool enabled = false;
@@ -34,7 +41,7 @@ struct ServerAdditionalConfig
     VoteConfig vote_restart;
     VoteConfig vote_next;
     VoteConfig vote_previous;
-    int spawn_protection_duration_ms = 1500;
+    SpawnProtectionConfig spawn_protection;
     std::optional<float> spawn_life;
     std::optional<float> spawn_armor;
     HitSoundsConfig hit_sounds;

--- a/game_patch/rf/multi.h
+++ b/game_patch/rf/multi.h
@@ -167,7 +167,7 @@ namespace rf
     static auto& multi_kill_local_player = addr_as_ref<void()>(0x004757A0);
     static auto& send_game_info_req_packet = addr_as_ref<void(const NetAddr& addr)>(0x0047B450);
     static auto& multi_entity_is_female = addr_as_ref<bool(int mp_character_idx)>(0x004762C0);
-
+    static auto& multi_powerup_add = addr_as_ref<void(Player* pp, int powerup_type, int time_ms)>(0x00480050);
     static auto& netgame = addr_as_ref<NetGameInfo>(0x0064EC28);
     static auto& is_multi = addr_as_ref<bool>(0x0064ECB9);
     static auto& is_server = addr_as_ref<bool>(0x0064ECBA);


### PR DESCRIPTION
This PR adjusts the implementation of spawn protection via the dedicated server config file in two ways:
- It is now a boolean on/off toggle with a duration optional parameter. This is very minor, but I think it is more intuitive than the previous method and aligns better with other options with configurable parameters like hitsounds. 
- It now has a new `$Use Powerup` optional setting (defaults false). If true, instead of using the standard method of spawn protection, grant newly spawned players an invulnerability powerup for the specified duration. This probably would never be used in normal servers but it would be fantastic for run servers. It's effectively what Cyrus and many other mappers were intending with all the invulnerability powerups scattered around.

New syntax for the configuration is (with default values shown):
```
$DF Spawn Protection Enabled: true
    +Duration: 1500
    +Use Powerup: false
```