### PR TITLE
Add console command to toggle muzzle flashes

### DIFF
--- a/common/include/common/config/GameConfig.h
+++ b/common/include/common/config/GameConfig.h
@@ -58,6 +58,7 @@ struct GameConfig
     CfgVar<bool> true_color_textures = true;
     CfgVar<bool> damage_screen_flash = true;
     CfgVar<bool> mesh_static_lighting = true;
+    CfgVar<bool> muzzle_flash = true;
     CfgVar<bool> glares = true;
     CfgVar<bool> show_enemy_bullets = true;
 

--- a/common/src/config/GameConfig.cpp
+++ b/common/src/config/GameConfig.cpp
@@ -181,6 +181,7 @@ bool GameConfig::visit_vars(T&& visitor, bool is_save)
     result &= visitor(dash_faction_key, "Big HUD", big_hud);
     result &= visitor(dash_faction_key, "Reticle Scale", reticle_scale);
     result &= visitor(dash_faction_key, "Mesh Static Lighting", mesh_static_lighting);
+    result &= visitor(dash_faction_key, "Muzzle Flash Lights", muzzle_flash);
     result &= visitor(dash_faction_key, "Player Join Beep", player_join_beep);
     result &= visitor(dash_faction_key, "Autosave", autosave);
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@ Version 1.9.0 (not released yet)
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
 - Fix crash when `verify_level` command is run without a level being loaded
+- Add `muzzle_flash` command
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/object/obj_light.cpp
+++ b/game_patch/object/obj_light.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 #include <xlog/xlog.h>
 #include <patch_common/FunHook.h>
+#include <patch_common/CallHook.h>
 #include <common/utils/list-utils.h>
 #include "../rf/object.h"
 #include "../rf/item.h"
@@ -133,6 +134,25 @@ ConsoleCommand2 mesh_static_lighting_cmd{
     "Toggle mesh static lighting calculation",
 };
 
+CallHook<void(rf::Entity*)> entity_update_muzzle_flash_light_hook{
+    0x0041E814,
+    [](rf::Entity* ep) {
+        if (g_game_config.muzzle_flash) {
+            entity_update_muzzle_flash_light_hook.call_target(ep);
+        }        
+    },
+};
+
+ConsoleCommand2 muzzle_flash_cmd{
+    "muzzle_flash",
+    []() {
+        g_game_config.muzzle_flash = !g_game_config.muzzle_flash;
+        g_game_config.save();
+        rf::console::print("Muzzle flash lights are {}", g_game_config.muzzle_flash ? "enabled" : "disabled");
+    },
+    "Toggle muzzle flash dynamic lights",
+};
+
 void obj_light_apply_patch()
 {
     // Fix/improve items and clutters static lighting calculation: fix matrices being zero and use static lights
@@ -143,6 +163,10 @@ void obj_light_apply_patch()
     // Fix invalid vertex offset in mesh lighting calculation
     write_mem<int8_t>(0x005042F0 + 2, sizeof(rf::Vector3));
 
+    // Don't create muzzle flash lights
+    entity_update_muzzle_flash_light_hook.install();
+
     // Commands
     mesh_static_lighting_cmd.register_cmd();
+    muzzle_flash_cmd.register_cmd();
 }


### PR DESCRIPTION
This PR adds the `muzzle_flash` command, which toggles whether the game should create muzzle flash dynamic lights.

This is separate from the global Dynamic Lighting toggle (in Video options in stock game) - that feature forces all dynamic lights off, including projectiles, CTF flags, amp/invuln, etc. The `muzzle_flash` option only affects muzzle flashes, and is very useful in multiplayer where muzzle flashing can get extremely annoying/headache-inducing but rendering dynamic lights for CTF flags and amp, etc. is preferred. I view this as an accessibility feature, similar to `damage_screen_flash`.

This feature was requested by heat. 