### PR TITLE
Add `/hasmap` chat command and support for extensions in `/vote map`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,8 @@ Version 1.9.0 (not released yet)
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
 - Fix crash when `verify_level` command is run without a level being loaded
+- Add `/hasmap` server chat command
+- Add handling of level filename extensions with `/vote level` server chat command
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -19,8 +19,8 @@
 #include "../misc/player.h"
 #include "../main/main.h"
 #include <common/utils/list-utils.h>
-#include "../rf/file/file.h"
 #include "../rf/player/player.h"
+#include "../rf/misc.h"
 #include "../rf/multi.h"
 #include "../rf/parse.h"
 #include "../rf/weapon.h"
@@ -234,8 +234,8 @@ void handle_has_map_command(rf::Player* player, std::string_view level_name)
     std::string checked_level_name = std::string(level_name);
     std::tie(is_valid, checked_level_name) = is_level_name_valid(checked_level_name);
 
-    auto msg = std::format("{}, this server does {}have level {} installed.", is_valid ? "Yes" : "No",
-                           is_valid ? "" : "NOT ", checked_level_name);
+    auto msg = std::format("{}, level {} is {}available on the server.", is_valid ? "Yes" : "No",
+                           checked_level_name, is_valid ? "" : "NOT ");
     send_chat_line_packet(msg.c_str(), player);
 }
 
@@ -577,8 +577,7 @@ std::pair<bool, std::string> is_level_name_valid(const std::string& level_name_i
         level_name += ".rfl";
     }
 
-    rf::File file;
-    bool is_valid = file.find(level_name.c_str());
+    bool is_valid = rf::get_file_checksum(level_name.c_str()) != 0;
 
     return {is_valid, level_name};
 }

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -230,12 +230,11 @@ void handle_next_map_command(rf::Player* player)
 
 void handle_has_map_command(rf::Player* player, std::string_view level_name)
 {
-    bool is_valid = false;
-    std::string checked_level_name = std::string(level_name);
-    std::tie(is_valid, checked_level_name) = is_level_name_valid(checked_level_name);
+    auto [is_valid, checked_level_name] = is_level_name_valid(level_name);
 
-    auto msg = std::format("{}, level {} is {}available on the server.", is_valid ? "Yes" : "No",
-                           checked_level_name, is_valid ? "" : "NOT ");
+    auto availability = is_valid ? "available" : "NOT available";
+    auto msg = std::format("Level {} is {} on the server.", checked_level_name, availability);
+
     send_chat_line_packet(msg.c_str(), player);
 }
 
@@ -569,9 +568,9 @@ static bool check_player_ac_status([[maybe_unused]] rf::Player* player)
     return true;
 }
 
-std::pair<bool, std::string> is_level_name_valid(const std::string& level_name_input)
+std::pair<bool, std::string> is_level_name_valid(std::string_view level_name_input)
 {
-    std::string level_name = level_name_input;
+    std::string level_name{level_name_input};
 
     if (level_name.size() < 4 || level_name.compare(level_name.size() - 4, 4, ".rfl") != 0) {
         level_name += ".rfl";

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -63,7 +63,7 @@ extern std::string g_prev_level;
 
 void cleanup_win32_server_console();
 void handle_vote_command(std::string_view vote_name, std::string_view vote_arg, rf::Player* sender);
-std::pair<bool, std::string> is_level_name_valid(const std::string& level_name_input);
+std::pair<bool, std::string> is_level_name_valid(std::string_view level_name_input);
 void server_vote_do_frame();
 void init_server_commands();
 void extend_round_time(int minutes);

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -63,6 +63,7 @@ extern std::string g_prev_level;
 
 void cleanup_win32_server_console();
 void handle_vote_command(std::string_view vote_name, std::string_view vote_arg, rf::Player* sender);
+std::pair<bool, std::string> is_level_name_valid(const std::string& level_name_input);
 void server_vote_do_frame();
 void init_server_commands();
 void extend_round_time(int minutes);

--- a/game_patch/multi/votes.cpp
+++ b/game_patch/multi/votes.cpp
@@ -245,11 +245,15 @@ struct VoteLevel : public Vote
 
     bool process_vote_arg([[maybe_unused]] std::string_view arg, rf::Player* source) override
     {
-        m_level_name = std::format("{}.rfl", arg);
-        if (!rf::get_file_checksum(m_level_name.c_str())) {
-            send_chat_line_packet("Cannot find specified level!", source);
+        auto [is_valid, level_name] = is_level_name_valid(std::string(arg));
+
+        if (!is_valid) {
+            auto msg = std::format("\xA6 Cannot start vote: level {} is not available on the server!", level_name);
+            send_chat_line_packet(msg.c_str(), source);
             return false;
         }
+
+        m_level_name = std::move(level_name);
         return true;
     }
 

--- a/game_patch/multi/votes.cpp
+++ b/game_patch/multi/votes.cpp
@@ -245,7 +245,7 @@ struct VoteLevel : public Vote
 
     bool process_vote_arg([[maybe_unused]] std::string_view arg, rf::Player* source) override
     {
-        auto [is_valid, level_name] = is_level_name_valid(std::string(arg));
+        auto [is_valid, level_name] = is_level_name_valid(arg);
 
         if (!is_valid) {
             auto msg = std::format("\xA6 Cannot start vote: level {} is not available on the server!", level_name);
@@ -264,7 +264,8 @@ struct VoteLevel : public Vote
 
     void on_accepted() override
     {
-        send_chat_line_packet("\xA6 Vote passed: changing level", nullptr);
+        auto msg = std::format("\xA6 Vote passed: changing level to {}", m_level_name);
+        send_chat_line_packet(msg.c_str(), nullptr);
         rf::multi_change_level(m_level_name.c_str());
     }
 


### PR DESCRIPTION
This PR:
- Adds the `is_level_name_valid` utility function, which takes a level filename as input (with or without extension), adds the .rfl extension if missing, and returns whether the server has that level installed.
- Adds the `/hasmap` server chat command (alias: `/haslevel`) - takes a level filename as input and outputs whether the map is installed on the server (and can therefore be voted for and played on).
- Implements the new utility function into the `/vote map` logic - adds support for specifying extensions when voting for maps. (previously, `/vote map dm02.rfl` wouldn't work, it will now)
- Adjusts the `Vote passed` message for change level votes to now print the level being switched to.