### PR TITLE
Improve handling for players leaving/joining multiplayer games during votes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@ Version 1.9.0 (not released yet)
 - Add level filename to "Level Initializing" console message
 - Properly handle WM_PAINT in dedicated server, may improve performance (DF bug)
 - Fix crash when `verify_level` command is run without a level being loaded
+- Improve handling for players leaving/joining multiplayer games during votes
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/game_patch/misc/player.cpp
+++ b/game_patch/misc/player.cpp
@@ -48,11 +48,11 @@ FunHook<rf::Player*(bool)> player_create_hook{
 FunHook<void(rf::Player*)> player_destroy_hook{
     0x004A35C0,
     [](rf::Player* player) {
+        multi_spectate_on_destroy_player(player);
+        player_destroy_hook.call_target(player);
         if (rf::is_server) {
             server_vote_on_player_leave(player);
         }
-        multi_spectate_on_destroy_player(player);
-        player_destroy_hook.call_target(player);
         g_player_additional_data_map.erase(player);
     },
 };

--- a/game_patch/misc/player.cpp
+++ b/game_patch/misc/player.cpp
@@ -11,6 +11,7 @@
 #include "../os/console.h"
 #include "../main/main.h"
 #include "../multi/multi.h"
+#include "../multi/server_internal.h"
 #include "../hud/multi_spectate.h"
 #include <common/utils/list-utils.h>
 #include <common/config/GameConfig.h>
@@ -50,6 +51,9 @@ FunHook<void(rf::Player*)> player_destroy_hook{
         multi_spectate_on_destroy_player(player);
         player_destroy_hook.call_target(player);
         g_player_additional_data_map.erase(player);
+        if (rf::is_server) {
+            server_vote_on_player_leave(player);
+        }
     },
 };
 

--- a/game_patch/misc/player.cpp
+++ b/game_patch/misc/player.cpp
@@ -48,12 +48,12 @@ FunHook<rf::Player*(bool)> player_create_hook{
 FunHook<void(rf::Player*)> player_destroy_hook{
     0x004A35C0,
     [](rf::Player* player) {
-        multi_spectate_on_destroy_player(player);
-        player_destroy_hook.call_target(player);
-        g_player_additional_data_map.erase(player);
         if (rf::is_server) {
             server_vote_on_player_leave(player);
         }
+        multi_spectate_on_destroy_player(player);
+        player_destroy_hook.call_target(player);
+        g_player_additional_data_map.erase(player);
     },
 };
 

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -554,6 +554,20 @@ static bool check_player_ac_status([[maybe_unused]] rf::Player* player)
     return true;
 }
 
+std::set<rf::Player*> get_current_player_list(bool include_browsers)
+{
+    std::set<rf::Player*> player_list;
+    auto linked_player_list = SinglyLinkedList{rf::player_list};
+
+    for (auto& player : linked_player_list) {
+        if (include_browsers || !get_player_additional_data(&player).is_browser) {
+            player_list.insert(&player);
+        }
+    }
+
+    return player_list;
+}
+
 FunHook<void(rf::Player*)> multi_spawn_player_server_side_hook{
     0x00480820,
     [](rf::Player* player) {

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -2,6 +2,7 @@
 
 #include <string_view>
 #include <string>
+#include <set>
 #include <map>
 #include <optional>
 
@@ -63,12 +64,14 @@ extern std::string g_prev_level;
 
 void cleanup_win32_server_console();
 void handle_vote_command(std::string_view vote_name, std::string_view vote_arg, rf::Player* sender);
+std::set<rf::Player*> get_current_player_list(bool include_browsers);
 void server_vote_do_frame();
 void init_server_commands();
 void extend_round_time(int minutes);
 void restart_current_level();
 void load_next_level();
 void load_prev_level();
+void server_vote_on_player_leave(rf::Player* player);
 void server_vote_on_limbo_state_enter();
 void process_delayed_kicks();
 const ServerAdditionalConfig& server_get_df_config();

--- a/game_patch/multi/votes.cpp
+++ b/game_patch/multi/votes.cpp
@@ -75,24 +75,19 @@ public:
             auto msg = std::format("\xA6 Vote status: Yes: {} No: {} Waiting: {}", yes_votes, no_votes,
                                    current_player_list.size() - players_who_voted.size());
             send_chat_line_packet(msg.c_str(), nullptr);
-
             return check_for_early_vote_finish();
         }
-
         return true;
     }
-
 
     bool do_frame()
     {
         const auto& vote_config = get_config();
         std::time_t passed_time_sec = std::time(nullptr) - start_time;
-
         if (passed_time_sec >= vote_config.time_limit_seconds) {
             send_chat_line_packet("\xA6 Vote timed out!", nullptr);
             return false;
         }
-
         if (passed_time_sec >= vote_config.time_limit_seconds / 2 && !reminder_sent) {
             const auto current_player_list = get_current_player_list(false);
 
@@ -101,13 +96,10 @@ public:
                     send_chat_line_packet("\xA6 Send message \"/vote yes\" or \"/vote no\" to vote.", player);
                 }
             }
-
             reminder_sent = true;
         }
-
         return true;
     }
-
 
     bool try_cancel_vote(rf::Player* source)
     {
@@ -187,12 +179,10 @@ protected:
             finish_vote(true);
             return false;
         }
-
         if (no_votes > yes_votes + remaining_players_count) {
             finish_vote(false);
             return false;
         }
-
         return true;
     }
 };


### PR DESCRIPTION
This PR adjusts voting in the following ways:
- When all players have left the server, an active vote is now automatically canceled.
- When the person who called a vote leaves the server, the vote is now automatically canceled.
- Newly joined players can now participate in the vote.
- Players who leave during a vote are now automatically removed from influence on the vote outcome - if they didn't vote, they're no longer considered; if they did vote, that vote is removed/ignored.

Previously, the behaviour for players who join/leave during a vote was relatively unintuitive - ie. players who joined during a vote were excluded from participating (despite receiving a reminder to do so), and a vote was still being expected from players who had already left the game.

This new approach is much more intuitive and is, I think, in line with how many players already thought the feature was working.