### PR TITLE
Improve PF packet logic

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,7 +50,7 @@ Version 1.9.0 (not released yet)
 [@is-this-c](https://github.com/is-this-c)
 - Support `©` in TrueType fonts
 - Improve frag message format
-- Search command descriptions for `.` command
+- Search command descriptions in `.` command
 - Improve PF network protocol compatibility
 
 [@Mystyle-48](https://github.com/Mystyle-48)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,9 +49,9 @@ Version 1.9.0 (not released yet)
 
 [@is-this-c](https://github.com/is-this-c)
 - Support `©` in TrueType fonts
-- Improve frag messages
-- Search in command descriptions in `.` command
-- Improve support for PF network protocol
+- Improve frag message format
+- Search command descriptions for `.` command
+- Improve PF network protocol compatibility
 
 [@Mystyle-48](https://github.com/Mystyle-48)
 - Simplify installation detection in setup and launcher

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,6 +52,7 @@ Contributions:
 
 - [@is-this-c](https://github.com/is-this-c)
   - Support `©` in TrueType fonts
+  - Improve PF packet logic
 
 Version 1.8.0 (released 2022-09-17)
 -----------------------------------

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,7 +51,7 @@ Version 1.9.0 (not released yet)
 - Support `©` in TrueType fonts
 - Improve frag messages
 - Search in command descriptions in `.` command
-- Improve PF packet logic
+- Improve support for PF network protocol
 
 [@Mystyle-48](https://github.com/Mystyle-48)
 - Simplify installation detection in setup and launcher

--- a/game_patch/misc/player.h
+++ b/game_patch/misc/player.h
@@ -1,10 +1,12 @@
 #include <functional>
 #include <map>
+#include <optional>
 #include <string>
 #include <common/utils/string-utils.h>
 #include "../rf/math/vector.h"
 #include "../rf/math/matrix.h"
 #include "../rf/os/timestamp.h"
+#include "../purefaction/pf_packets.h"
 
 // Forward declarations
 namespace rf
@@ -20,6 +22,7 @@ struct PlayerNetGameSaveData
 
 struct PlayerAdditionalData
 {
+    std::optional<pf_pure_status> received_ac_status{};
     bool is_browser = false;
     bool is_muted = false;
     int last_hitsound_sent_ms = 0;

--- a/game_patch/multi/multi.h
+++ b/game_patch/multi/multi.h
@@ -13,6 +13,7 @@ struct PlayerStatsNew : rf::PlayerLevelStats
     float num_shots_fired;
     float damage_received;
     float damage_given;
+    std::optional<uint8_t> received_accuracy{};
 
     void inc_kills()
     {
@@ -67,6 +68,7 @@ struct PlayerStatsNew : rf::PlayerLevelStats
         max_streak = 0;
         damage_received = 0;
         damage_given = 0;
+        received_accuracy.reset();
     }
 };
 

--- a/game_patch/multi/network.cpp
+++ b/game_patch/multi/network.cpp
@@ -1029,7 +1029,7 @@ CodeInjection multi_io_process_packets_injection{
     0x0047918D,
     [](auto& regs) {
         int packet_type = regs.esi;
-        if (packet_type > 0x37) {
+        if (packet_type > 0x37 || packet_type == static_cast<int>(pf_packet_type::player_stats)) {
             auto stack_frame = regs.esp + 0x1C;
             std::byte* data = regs.ecx;
             int offset = regs.ebp;

--- a/game_patch/purefaction/pf.cpp
+++ b/game_patch/purefaction/pf.cpp
@@ -174,7 +174,8 @@ static void process_pf_player_stats_packet(const void* data, size_t len, [[ mayb
         if (player) {
             auto& stats = *static_cast<PlayerStatsNew*>(player->stats);
             if (in_stats.is_pure <= static_cast<uint8_t>(pf_pure_status::_last_variant)) {
-                stats.received_ac_status = std::optional{static_cast<pf_pure_status>(in_stats.is_pure)};
+                get_player_additional_data(player).received_ac_status
+                    = std::optional{static_cast<pf_pure_status>(in_stats.is_pure)};
             }
             stats.received_accuracy = std::optional{in_stats.accuracy};
             stats.max_streak = in_stats.streak_max;

--- a/game_patch/purefaction/pf.cpp
+++ b/game_patch/purefaction/pf.cpp
@@ -173,7 +173,9 @@ static void process_pf_player_stats_packet(const void* data, size_t len, [[ mayb
         auto* player = rf::multi_find_player_by_id(in_stats.player_id);
         if (player) {
             auto& stats = *static_cast<PlayerStatsNew*>(player->stats);
-            // Ignore `is_pure`.  Why is it in `player_stats`? 
+            if (in_stats.is_pure <= static_cast<uint8_t>(pf_pure_status::_last_variant)) {
+                stats.received_ac_status = std::optional{static_cast<pf_pure_status>(in_stats.is_pure)};
+            }
             stats.received_accuracy = std::optional{in_stats.accuracy};
             stats.max_streak = in_stats.streak_max;
             stats.current_streak = in_stats.streak_current;

--- a/game_patch/purefaction/pf.cpp
+++ b/game_patch/purefaction/pf.cpp
@@ -37,8 +37,11 @@ static void send_pf_announce_player_packet(rf::Player* player, pf_pure_status pu
     announce_packet.hdr.size = sizeof(announce_packet) - sizeof(announce_packet.hdr);
     announce_packet.version = pf_announce_player_packet_version;
     announce_packet.player_id = player->net_data->player_id;
-    announce_packet.is_pure = static_cast<uint8_t>(get_player_additional_data(player).is_browser
-        ? pf_pure_status::rfsb : pure_status);
+    announce_packet.is_pure = static_cast<uint8_t>(
+        get_player_additional_data(player).is_browser
+        ? pf_pure_status::rfsb
+        : pure_status
+    );
 
     auto player_list = SinglyLinkedList(rf::player_list);
     for (auto& other_player : player_list) {
@@ -53,7 +56,7 @@ static void process_pf_player_announce_packet(const void* data, size_t len, [[ m
         return;
     }
 
-    pf_player_announce_packet announce_packet;
+    pf_player_announce_packet announce_packet{};
     if (len < sizeof(announce_packet)) {
         xlog::trace("Invalid length in PF player_announce packet");
         return;
@@ -78,9 +81,10 @@ static void process_pf_player_announce_packet(const void* data, size_t len, [[ m
         static constinit const std::array<std::string_view, 6> pf_verification_status_names{
             {"none", "blue", "gold", "fail", "old_blue", "rfsb"}
         };
-        const std::string_view pf_verification_status =
-            announce_packet.is_pure < std::size(pf_verification_status_names)
-            ? pf_verification_status_names[announce_packet.is_pure] : "unknown";
+        const std::string_view pf_verification_status
+            = announce_packet.is_pure < std::size(pf_verification_status_names)
+            ? pf_verification_status_names[announce_packet.is_pure]
+            : "unknown";
         xlog::info("PF Verification Status: {} ({})", pf_verification_status, announce_packet.is_pure);
     }
 }
@@ -91,7 +95,7 @@ void send_pf_player_stats_packet(rf::Player* player)
     assert(rf::is_server);
 
     std::byte packet_buf[rf::max_packet_size];
-    pf_player_stats_packet stats_packet;
+    pf_player_stats_packet stats_packet{};
     stats_packet.hdr.type = static_cast<uint8_t>(pf_packet_type::player_stats);
     stats_packet.hdr.size = sizeof(stats_packet) - sizeof(stats_packet.hdr);
     stats_packet.version = pf_player_stats_packet_version;
@@ -101,10 +105,13 @@ void send_pf_player_stats_packet(rf::Player* player)
     auto player_list = SinglyLinkedList{rf::player_list};
     for (auto& current_player : player_list) {
         auto& player_stats = *static_cast<PlayerStatsNew*>(current_player.stats);
-        pf_player_stats_packet::player_stats out_stats;
+        pf_player_stats_packet::player_stats out_stats{};
         out_stats.player_id = current_player.net_data->player_id;
-        out_stats.is_pure = static_cast<uint8_t>(get_player_additional_data(&current_player).is_browser
-            ? pf_pure_status::rfsb : pf_ac_get_pure_status(&current_player));
+        out_stats.is_pure = static_cast<uint8_t>(
+            get_player_additional_data(&current_player).is_browser
+            ? pf_pure_status::rfsb
+            : pf_ac_get_pure_status(&current_player)
+        );
         out_stats.accuracy = static_cast<uint8_t>(player_stats.calc_accuracy() * 100.f);
         out_stats.streak_max = player_stats.max_streak;
         out_stats.streak_current = player_stats.current_streak;
@@ -141,7 +148,7 @@ static void process_pf_player_stats_packet(const void* data, size_t len, [[ mayb
         return;
     }
 
-    pf_player_stats_packet stats_packet;
+    pf_player_stats_packet stats_packet{};
     if (len < sizeof(stats_packet)) {
         xlog::trace("Invalid length in PF player_stats packet");
         return;
@@ -163,7 +170,7 @@ static void process_pf_player_stats_packet(const void* data, size_t len, [[ mayb
 
     const std::byte* player_stats_ptr = static_cast<const std::byte*>(data) + sizeof(stats_packet);
     for (int i = 0; i < stats_packet.player_count; ++i) {
-        pf_player_stats_packet::player_stats in_stats;
+        pf_player_stats_packet::player_stats in_stats{};
         std::memcpy(&in_stats, player_stats_ptr, sizeof(in_stats));
         player_stats_ptr += sizeof(in_stats);
         auto* player = rf::multi_find_player_by_id(in_stats.player_id);
@@ -191,7 +198,7 @@ static void process_pf_players_request_packet([[ maybe_unused ]] const void* dat
         return;
     }
 
-    pf_players_packet players_packet;
+    pf_players_packet players_packet{};
     players_packet.hdr.type = static_cast<uint8_t>(pf_packet_type::players);
     players_packet.version = 1;
     players_packet.show_ip = 0;
@@ -220,7 +227,7 @@ bool pf_process_packet(const void* data, int len, const rf::NetAddr& addr, rf::P
         return true;
     }
 
-    rf_packet_header header;
+    rf_packet_header header{};
     if (len < static_cast<int>(sizeof(header))) {
         return false;
     }
@@ -247,7 +254,7 @@ bool pf_process_packet(const void* data, int len, const rf::NetAddr& addr, rf::P
 
 bool pf_process_raw_unreliable_packet(const void* data, int len, const rf::NetAddr& addr)
 {
-    rf_packet_header header;
+    rf_packet_header header{};
     if (len < static_cast<int>(sizeof(header))) {
         return false;
     }

--- a/game_patch/purefaction/pf.cpp
+++ b/game_patch/purefaction/pf.cpp
@@ -38,9 +38,7 @@ static void send_pf_announce_player_packet(rf::Player* player, pf_pure_status pu
     announce_packet.version = pf_announce_player_packet_version;
     announce_packet.player_id = player->net_data->player_id;
     announce_packet.is_pure = static_cast<uint8_t>(
-        get_player_additional_data(player).is_browser
-        ? pf_pure_status::rfsb
-        : pure_status
+        get_player_additional_data(player).is_browser ? pf_pure_status::rfsb : pure_status
     );
 
     auto player_list = SinglyLinkedList(rf::player_list);
@@ -107,10 +105,9 @@ void send_pf_player_stats_packet(rf::Player* player)
         auto& player_stats = *static_cast<PlayerStatsNew*>(current_player.stats);
         pf_player_stats_packet::player_stats out_stats{};
         out_stats.player_id = current_player.net_data->player_id;
+        const pf_pure_status pure_status = pf_ac_get_pure_status(&current_player);
         out_stats.is_pure = static_cast<uint8_t>(
-            get_player_additional_data(&current_player).is_browser
-            ? pf_pure_status::rfsb
-            : pf_ac_get_pure_status(&current_player)
+            get_player_additional_data(&current_player).is_browser ? pf_pure_status::rfsb : pure_status
         );
         out_stats.accuracy = static_cast<uint8_t>(player_stats.calc_accuracy() * 100.f);
         out_stats.streak_max = player_stats.max_streak;

--- a/game_patch/purefaction/pf_packets.h
+++ b/game_patch/purefaction/pf_packets.h
@@ -24,6 +24,7 @@ enum class pf_pure_status : uint8_t
     fail = 3,
     old_pure = 4,
     rfsb = 5,
+    _last_variant = rfsb,
 };
 
 struct rf_packet_header


### PR DESCRIPTION
Recognize browsers and also support anticheat status and fire accuracy.

I cannot change anticheat code so it is a best effort.

This PR does not fix that `send_pf_player_stats_packet` is not regularly called.