### PR TITLE
Do not use /Zc:threadSafeInit- (deprecated Windows XP support)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,8 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 if(MSVC)
-    add_compile_options(/Zc:threadSafeInit-)
+    # `Zc:threadSafeInit-` is required by Windows XP.
+    # add_compile_options(/Zc:threadSafeInit-)   
     add_compile_options(/arch:IA32)
     # Statically link Microsoft's CRT.
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,6 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 if(MSVC)
-    # `Zc:threadSafeInit-` is required by Windows XP.
-    # add_compile_options(/Zc:threadSafeInit-)   
     add_compile_options(/arch:IA32)
     # Statically link Microsoft's CRT.
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")


### PR DESCRIPTION
Could delete. But it might be useful to just comment it out since it is kind of obscure so it can be enabled if anybody ever wanted to fix DF to run on Windows XP.