### PR TITLE
Increase warning level for Visual C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ endif()
 macro(enable_warnings target)
     if(NOT MSVC)
         target_compile_options(${target} PRIVATE -Wall -Wextra -Wundef)
+    else()
+        target_compile_options(${target} PRIVATE /W3)
     endif()
 endmacro()
 


### PR DESCRIPTION
Increases from the default `/W1` to `/W3` which gives about 10 warnings. `/W4` is about 1k.