### PR TITLE
Fix {Singly,Doubly}LinkedList

### DIFF
--- a/common/include/common/utils/list-utils.h
+++ b/common/include/common/utils/list-utils.h
@@ -111,7 +111,7 @@ public:
 
         self_type operator++([[maybe_unused]] int junk)
         {
-            self_type copy = *this;
+            const self_type copy = *this;
             ++*this;
             return copy;
         }
@@ -140,6 +140,6 @@ public:
 
     Iterator end()
     {
-        return Iterator(&m_list);
+        return Iterator(m_list);
     }
 };

--- a/common/include/common/utils/list-utils.h
+++ b/common/include/common/utils/list-utils.h
@@ -25,7 +25,9 @@ public:
             current(first), first(first)
         {}
 
-        self_type operator++()
+        Iterator() = default;
+
+        self_type& operator++()
         {
             current = current->*NEXT_PTR;
             if (current == first) {
@@ -36,8 +38,8 @@ public:
 
         self_type operator++([[maybe_unused]] int junk)
         {
-            self_type copy = *this;
-            ++copy;
+            const self_type copy = *this;
+            ++*this;
             return copy;
         }
 

--- a/common/include/common/utils/list-utils.h
+++ b/common/include/common/utils/list-utils.h
@@ -90,7 +90,7 @@ public:
         using value_type = T;
         using reference = T&;
         using pointer = T*;
-        using iterator_category = std::forward_iterator_tag;
+        using iterator_category = std::bidirectional_iterator_tag;
         using difference_type = int;
 
         Iterator() :
@@ -111,6 +111,12 @@ public:
         {
             current = current->*PREV_PTR;
             return *this;
+        }
+
+        self_type operator--([[maybe_unused]] int junk) {
+            const self_type copy = *this;
+            --*this;
+            return copy;
         }
 
         self_type operator++([[maybe_unused]] int junk)

--- a/common/include/common/utils/list-utils.h
+++ b/common/include/common/utils/list-utils.h
@@ -21,11 +21,13 @@ public:
         using iterator_category = std::forward_iterator_tag;
         using difference_type = int;
 
+        Iterator() :
+            Iterator{nullptr}
+        {}
+
         Iterator(pointer first) :
             current(first), first(first)
         {}
-
-        Iterator() = default;
 
         self_type& operator++()
         {
@@ -91,11 +93,13 @@ public:
         using iterator_category = std::forward_iterator_tag;
         using difference_type = int;
 
+        Iterator() :
+            Iterator{nullptr}
+        {}
+
         Iterator(pointer current) :
             current(current)
         {}
-
-        Iterator() = default;
 
         self_type& operator++()
         {

--- a/common/include/common/utils/list-utils.h
+++ b/common/include/common/utils/list-utils.h
@@ -5,7 +5,7 @@
 template<typename T, T* T::*NEXT_PTR = &T::next>
 class SinglyLinkedList
 {
-    T*& m_list;
+    T* m_list;
 
 public:
     class Iterator
@@ -59,7 +59,7 @@ public:
         }
     };
 
-    SinglyLinkedList(T*& list) : m_list(list)
+    SinglyLinkedList(T* list) : m_list(list)
     {}
 
     Iterator begin()
@@ -76,7 +76,7 @@ public:
 template<typename T, T* T::*NEXT_PTR = &T::next, T* T::*PREV_PTR = &T::prev>
 class DoublyLinkedList
 {
-    T& m_list;
+    T* m_list;
 
 public:
     class Iterator
@@ -95,13 +95,15 @@ public:
             current(current)
         {}
 
-        self_type operator++()
+        Iterator() = default;
+
+        self_type& operator++()
         {
             current = current->*NEXT_PTR;
             return *this;
         }
 
-        self_type operator--()
+        self_type& operator--()
         {
             current = current->*PREV_PTR;
             return *this;
@@ -110,7 +112,7 @@ public:
         self_type operator++([[maybe_unused]] int junk)
         {
             self_type copy = *this;
-            ++copy;
+            ++*this;
             return copy;
         }
 
@@ -127,12 +129,12 @@ public:
         }
     };
 
-    DoublyLinkedList(T& list) : m_list(list)
+    DoublyLinkedList(T& list) : m_list(&list)
     {}
 
     Iterator begin()
     {
-        auto next = m_list.next ? m_list.next : &m_list;
+        auto next = m_list->next ? m_list->next : m_list;
         return Iterator(next);
     }
 

--- a/common/include/common/utils/list-utils.h
+++ b/common/include/common/utils/list-utils.h
@@ -5,13 +5,13 @@
 template<typename T, T* T::*NEXT_PTR = &T::next>
 class SinglyLinkedList
 {
-    T* m_list;
+    std::reference_wrapper<T*> m_list;
 
 public:
     class Iterator
     {
         T* current;
-        T* first;
+        const T* first;
 
     public:
         using self_type = Iterator;
@@ -25,8 +25,9 @@ public:
             Iterator{nullptr}
         {}
 
-        Iterator(pointer first) :
-            current(first), first(first)
+        Iterator(const pointer first) :
+            current{first},
+            first{first}
         {}
 
         self_type& operator++()
@@ -38,7 +39,7 @@ public:
             return *this;
         }
 
-        self_type operator++([[maybe_unused]] int junk)
+        self_type operator++([[maybe_unused]] const int junk)
         {
             const self_type copy = *this;
             ++*this;
@@ -61,24 +62,25 @@ public:
         }
     };
 
-    SinglyLinkedList(T* list) : m_list(list)
+    SinglyLinkedList(T*& list) :
+        m_list{list}
     {}
 
     Iterator begin()
     {
-        return Iterator(m_list);
+        return Iterator{m_list};
     }
 
     Iterator end()
     {
-        return Iterator(nullptr);
+        return Iterator{nullptr};
     }
 };
 
 template<typename T, T* T::*NEXT_PTR = &T::next, T* T::*PREV_PTR = &T::prev>
 class DoublyLinkedList
 {
-    T* m_list;
+    std::reference_wrapper<T> m_list;
 
 public:
     class Iterator
@@ -97,8 +99,8 @@ public:
             Iterator{nullptr}
         {}
 
-        Iterator(pointer current) :
-            current(current)
+        Iterator(const pointer current) :
+            current{current}
         {}
 
         self_type& operator++()
@@ -113,13 +115,13 @@ public:
             return *this;
         }
 
-        self_type operator--([[maybe_unused]] int junk) {
+        self_type operator--([[maybe_unused]] const int junk) {
             const self_type copy = *this;
             --*this;
             return copy;
         }
 
-        self_type operator++([[maybe_unused]] int junk)
+        self_type operator++([[maybe_unused]] const int junk)
         {
             const self_type copy = *this;
             ++*this;
@@ -139,17 +141,22 @@ public:
         }
     };
 
-    DoublyLinkedList(T& list) : m_list(&list)
+    DoublyLinkedList(T& list) :
+        m_list{list}
     {}
 
     Iterator begin()
     {
-        auto next = m_list->next ? m_list->next : m_list;
-        return Iterator(next);
+        T* const next = m_list.get().next;
+        if (next) {
+            return Iterator{next};
+        } else {
+            return end();
+        }
     }
 
     Iterator end()
     {
-        return Iterator(m_list);
+        return Iterator{&m_list.get()};
     }
 };

--- a/common/include/common/utils/list-utils.h
+++ b/common/include/common/utils/list-utils.h
@@ -2,7 +2,7 @@
 
 #include <iterator>
 
-template<typename T, T* T::*NEXT_PTR = &T::next>
+template<typename T, T* const T::*NEXT_PTR = &T::next>
 class SinglyLinkedList
 {
     std::reference_wrapper<T*> m_list;
@@ -77,7 +77,7 @@ public:
     }
 };
 
-template<typename T, T* T::*NEXT_PTR = &T::next, T* T::*PREV_PTR = &T::prev>
+template<typename T, T* const T::*NEXT_PTR = &T::next, T* const T::*PREV_PTR = &T::prev>
 class DoublyLinkedList
 {
     std::reference_wrapper<T> m_list;


### PR DESCRIPTION
Fixes `{Singly,Doubly}LinkedList` to work with C++ ranges and also fixes logic errors in `{Singly,Doubly}LinkedList::Iterator::operator++`.

C++ ranges does not seem to like references in these structs nor could I make these pointers `const`!