### PR TITLE
Erase `rf::local_player` from `g_player_additional_data_map` upon leaving server.

### DIFF
--- a/game_patch/misc/player.cpp
+++ b/game_patch/misc/player.cpp
@@ -30,6 +30,10 @@ void find_player(const StringMatcher& query, std::function<void(rf::Player*)> co
     }
 }
 
+void reset_player_additional_data(const rf::Player* const player) {
+    g_player_additional_data_map.erase(player);
+}
+
 PlayerAdditionalData& get_player_additional_data(rf::Player* player)
 {
     return g_player_additional_data_map[player];
@@ -48,8 +52,8 @@ FunHook<void(rf::Player*)> player_destroy_hook{
     0x004A35C0,
     [](rf::Player* player) {
         multi_spectate_on_destroy_player(player);
+        reset_player_additional_data(player);
         player_destroy_hook.call_target(player);
-        g_player_additional_data_map.erase(player);
     },
 };
 

--- a/game_patch/misc/player.cpp
+++ b/game_patch/misc/player.cpp
@@ -19,7 +19,7 @@
 #include <patch_common/CodeInjection.h>
 #include <patch_common/AsmWriter.h>
 
-std::unordered_map<rf::Player*, PlayerAdditionalData> g_player_additional_data_map;
+std::unordered_map<const rf::Player*, PlayerAdditionalData> g_player_additional_data_map;
 
 void find_player(const StringMatcher& query, std::function<void(rf::Player*)> consumer)
 {

--- a/game_patch/misc/player.h
+++ b/game_patch/misc/player.h
@@ -32,4 +32,5 @@ struct PlayerAdditionalData
 };
 
 void find_player(const StringMatcher& query, std::function<void(rf::Player*)> consumer);
+void reset_player_additional_data(const rf::Player* player);
 PlayerAdditionalData& get_player_additional_data(rf::Player* player);

--- a/game_patch/multi/network.cpp
+++ b/game_patch/multi/network.cpp
@@ -892,8 +892,7 @@ FunHook<void()> multi_stop_hook{
         g_df_server_info.reset();
         multi_stop_hook.call_target();
         if (rf::local_player) {
-            extern std::unordered_map<rf::Player*, PlayerAdditionalData> g_player_additional_data_map;
-            g_player_additional_data_map.erase(rf::local_player);
+            reset_player_additional_data(rf::local_player);
         }
     },
 };

--- a/game_patch/multi/network.cpp
+++ b/game_patch/multi/network.cpp
@@ -891,6 +891,10 @@ FunHook<void()> multi_stop_hook{
         // Clear server info when leaving
         g_df_server_info.reset();
         multi_stop_hook.call_target();
+        if (rf::local_player) {
+            extern std::unordered_map<rf::Player*, PlayerAdditionalData> g_player_additional_data_map;
+            g_player_additional_data_map.erase(rf::local_player);
+        }
     },
 };
 


### PR DESCRIPTION
Ensures `received_ac_status` etc. is cleared.