### PR TITLE
Allow console command and level filename autocomplete from 1 character

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,7 +53,7 @@ Version 1.9.0 (not released yet)
 - Add mod name to main menu
 - Make value of `spectate_mode_minimal_ui` persist between game launches
 - Add `version` command
-- Support autocompleting of console command names from only 1 character
+- Support autocompleting of level filenames and console commands from only 1 character
 
 [@is-this-c](https://github.com/is-this-c)
 - Support `©` in TrueType fonts

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,6 +53,7 @@ Version 1.9.0 (not released yet)
 - Add mod name to main menu
 - Make value of `spectate_mode_minimal_ui` persist between game launches
 - Add `version` command
+- Support autocompleting of console command names from only 1 character
 
 [@is-this-c](https://github.com/is-this-c)
 - Support `©` in TrueType fonts

--- a/game_patch/os/autocomplete.cpp
+++ b/game_patch/os/autocomplete.cpp
@@ -92,7 +92,7 @@ void console_auto_complete_level(int offset)
 {
     std::string level_name;
     console_auto_complete_get_component(offset, level_name);
-    if (level_name.size() < 3)
+    if (level_name.size() < 1)
         return;
 
     bool first = true;

--- a/game_patch/os/autocomplete.cpp
+++ b/game_patch/os/autocomplete.cpp
@@ -92,7 +92,7 @@ void console_auto_complete_level(int offset)
 {
     std::string level_name;
     console_auto_complete_get_component(offset, level_name);
-    if (level_name.size() < 1)
+    if (level_name.empty())
         return;
 
     bool first = true;

--- a/game_patch/os/autocomplete.cpp
+++ b/game_patch/os/autocomplete.cpp
@@ -144,7 +144,7 @@ void console_auto_complete_command(int offset)
 {
     std::string cmd_name;
     int next_offset = console_auto_complete_get_component(offset, cmd_name);
-    if (cmd_name.size() < 2)
+    if (cmd_name.size() < 1)
         return;
 
     bool first = true;

--- a/game_patch/os/autocomplete.cpp
+++ b/game_patch/os/autocomplete.cpp
@@ -144,7 +144,7 @@ void console_auto_complete_command(int offset)
 {
     std::string cmd_name;
     int next_offset = console_auto_complete_get_component(offset, cmd_name);
-    if (cmd_name.size() < 1)
+    if (cmd_name.empty())
         return;
 
     bool first = true;


### PR DESCRIPTION
Current code allows autocompleting of console commands from 2 characters, and level filenames from 3 characters. This changes the minimum for both to just 1 character.

Makes working with console commands and maps slightly easier in some cases. I don't know of a downside to this (please correct me if I am missing something).