### PR TITLE
Allow player to pick up Super Health and Super Armor powerups in single player

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,6 +53,7 @@ Version 1.9.0 (not released yet)
 - Add mod name to main menu
 - Make value of `spectate_mode_minimal_ui` persist between game launches
 - Add `version` command
+- Support Super Health and Super Armor powerups in single player
 
 [@is-this-c](https://github.com/is-this-c)
 - Support `©` in TrueType fonts

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,7 +53,7 @@ Version 1.9.0 (not released yet)
 - Add mod name to main menu
 - Make value of `spectate_mode_minimal_ui` persist between game launches
 - Add `version` command
-- Support Super Health and Super Armor powerups in single player
+- Allow player to pick up Super Health and Super Armor powerups in single player
 
 [@is-this-c](https://github.com/is-this-c)
 - Support `©` in TrueType fonts

--- a/game_patch/object/item.cpp
+++ b/game_patch/object/item.cpp
@@ -1,3 +1,4 @@
+#include <patch_common/AsmWriter.h>
 #include <patch_common/FunHook.h>
 #include <patch_common/CodeInjection.h>
 #include "../rf/item.h"
@@ -62,6 +63,10 @@ CodeInjection item_create_sort_injection{
 
 void item_do_patch()
 {
+    // Allow player to pick up super health and super armor in single player
+    AsmWriter{0x0048012B}.jmp(0x00480135);
+    AsmWriter{0x0045AAFD}.jmp(0x0045AB11);
+
     // Allow overriding weapon items count value
     item_touch_weapon_hook.install();
 


### PR DESCRIPTION
Self explanatory

Also does allow amp/invuln to be picked up and show fpgun overlay (but no actual powerup effect) in SP. This isn't intentional, but I don't necessarily think it's a problem - the powerups were never functional in SP anyway, so it's not like any maps would intentionally include them.

It would take additional code to specifically stop the amp/invuln overlay, and given I would like to support those powerups in SP eventually as well (just not with this PR), I don't know that it makes sense to write additional code that would have to be removed at that point, and is solving something that isn't _really_ a problem now.