### PR TITLE
Use `🖥︎` in welcome message

### DIFF
--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -650,7 +650,7 @@ void server_reliable_socket_ready(rf::Player* player)
 {
     if (!g_additional_server_config.welcome_message.empty()) {
         auto msg = string_replace(g_additional_server_config.welcome_message, "$PLAYER", player->name.c_str());
-        send_chat_line_packet(msg.c_str(), player);
+        send_chat_line_packet(std::format("\xA6 {}", msg).c_str(), player);
     }
 }
 


### PR DESCRIPTION
I do not like how server messages are not differentiated from operator messages but I am not sure how to resolve. The welcome message can be anything however so I think it needs differentiation with `🖥︎` .