### PR TITLE
Call `pf_player_verified` even if a server has no anticheat

### DIFF
--- a/game_patch/purefaction/pf_ac_stubs.cpp
+++ b/game_patch/purefaction/pf_ac_stubs.cpp
@@ -12,8 +12,9 @@ void pf_ac_init_player(rf::Player*)
 {
 }
 
-void pf_ac_verify_player(rf::Player*)
+void pf_ac_verify_player(rf::Player* const player)
 {
+    pf_player_verified(player, pf_pure_status::none);
 }
 
 pf_pure_status pf_ac_get_pure_status(rf::Player*)


### PR DESCRIPTION
This logic should have been included in #306.

Currently it will cause a `pf_announce_player_packet` and a `pf_player_stats_packet` to be sent which is desired.