### PR TITLE
Fix numeric keypad

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 1.9.2 (not released yet)
 [@is-this-c](https://github.com/is-this-c)
 - Fix a potential crash after a client quits a game if Directd3D 11 is enabled
 - Improve compatibility with Alpine Faction servers
+- Support `PgUp` and `PgDown` etc. on numeric keypads
 
 Version 1.9.1 (released 2025-07-05)
 --------------------------------

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ Version 1.9.2 (not released yet)
 [@is-this-c](https://github.com/is-this-c)
 - Fix a potential crash after a client quits a game if Directd3D 11 is enabled
 - Improve compatibility with Alpine Faction servers
-- Support `PgUp` and `PgDown` etc. on numeric keypads
+- Fix `PgUp`, `PgDown`, `End`, and `Home` on numeric keypads
 
 Version 1.9.1 (released 2025-07-05)
 --------------------------------

--- a/game_patch/input/key.cpp
+++ b/game_patch/input/key.cpp
@@ -126,14 +126,17 @@ CodeInjection key_get_hook{
 CodeInjection key_down_handler_injection{
     0x0051E9AC,
     [] (auto& regs) {
-        const int w_param = addr_as_ref<int>(regs.esp + 4);
-        // The scan code may be wrong for these keys, if it was from a numeric keypad.
-        if (w_param == VK_PRIOR) {
-            regs.eax = rf::KEY_PAGEUP;
-        } else if (w_param == VK_NEXT) {
-            regs.eax = rf::KEY_PAGEDOWN;
-        } else if (w_param == VK_END) {
-            regs.eax = rf::KEY_END;
+        const int virtual_key = addr_as_ref<int>(regs.esp + 4);
+        // For numeric keypads, we need to fix these keys' scan codes.
+        auto& scan_code = regs.eax;
+        if (virtual_key == VK_PRIOR) {
+            scan_code = rf::KEY_PAGEUP;
+        } else if (virtual_key == VK_NEXT) {
+            scan_code = rf::KEY_PAGEDOWN;
+        } else if (virtual_key == VK_END) {
+            scan_code = rf::KEY_END;
+        } else if (virtual_key == VK_HOME) {
+            scan_code = rf::KEY_HOME;
         }
     },
 };

--- a/game_patch/input/key.cpp
+++ b/game_patch/input/key.cpp
@@ -123,6 +123,21 @@ CodeInjection key_get_hook{
     },
 };
 
+CodeInjection key_down_handler_injection{
+    0x0051E9AC,
+    [] (auto& regs) {
+        const int w_param = addr_as_ref<int>(regs.esp + 4);
+        // The scan code may be wrong for these keys, if it was from a numeric keypad.
+        if (w_param == VK_PRIOR) {
+            regs.eax = rf::KEY_PAGEUP;
+        } else if (w_param == VK_NEXT) {
+            regs.eax = rf::KEY_PAGEDOWN;
+        } else if (w_param == VK_END) {
+            regs.eax = rf::KEY_END;
+        }
+    },
+};
+
 void key_apply_patch()
 {
     // Support non-US keyboard layouts
@@ -135,4 +150,6 @@ void key_apply_patch()
 
     // win32 console support and addition of os_poll
     key_get_hook.install();
+
+    key_down_handler_injection.install();
 }


### PR DESCRIPTION
`PgUp` and `PgDn` etc. are located upon my keyboard's numeric keypad. They do not work for me without this fix. I noticed that the scan code for these keys is not effected by whether Num Lock is on or off. 