### PR TITLE
Fix text

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,6 @@ Version 1.9.2 (not released yet)
 - Set `rf::gr::text_2d_mode` to ignore fog
 - Fix `gr_d3d_bitmap`, so `gr_d3d_set_state` is called earlier
 - Fix a potential crash, after a client quits a game, if Directd3D 11 is enabled
-- Fix a potential crash after a client quits a game if Directd3D 11 is enabled
 - Improve compatibility with Alpine Faction servers
 - Fix `PgUp`, `PgDown`, `End`, and `Home` on numeric keypads
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,8 @@ Dash Faction Changelog
 Version 1.9.2 (not released yet)
 --------------------------------
 [@is-this-c](https://github.com/is-this-c)
-- Fix a potential crash after a client quits a game if Directd3D 11 is enabled
+- Set `rf::gr::text_2d_mode` to ignore fog
+- Fix a potential crash, after a client quits a game, if Directd3D 11 is enabled
 - Improve compatibility with Alpine Faction servers
 - Fix `PgUp`, `PgDown`, `End`, and `Home` on numeric keypads
 

--- a/game_patch/graphics/gr.cpp
+++ b/game_patch/graphics/gr.cpp
@@ -330,4 +330,7 @@ void gr_apply_patch()
     windowed_cmd.register_cmd();
     nearest_texture_filtering_cmd.register_cmd();
     lod_distance_scale_cmd.register_cmd();
+
+    // Fix `rf::gr::text_2d_mode`.
+    AsmWriter{0x0050BB40}.push(rf::gr::FOG_NOT_ALLOWED);
 }

--- a/game_patch/graphics/gr.cpp
+++ b/game_patch/graphics/gr.cpp
@@ -332,5 +332,5 @@ void gr_apply_patch()
     lod_distance_scale_cmd.register_cmd();
 
     // Fix `rf::gr::text_2d_mode`.
-    AsmWriter{0x0050BB40}.push(rf::gr::FOG_NOT_ALLOWED);
+    AsmWriter{0x0050BB40}.push(static_cast<uint8_t>(rf::gr::FOG_NOT_ALLOWED));
 }

--- a/game_patch/rf/gr/gr.h
+++ b/game_patch/rf/gr/gr.h
@@ -52,7 +52,7 @@ namespace rf::gr
     };
     static_assert(sizeof(Vertex) == 0x30);
 
-    enum TextureSource : uint8_t {
+    enum TextureSource {
         TEXTURE_SOURCE_NONE = 0x0,
         TEXTURE_SOURCE_WRAP = 0x1,
         TEXTURE_SOURCE_CLAMP = 0x2,
@@ -67,7 +67,7 @@ namespace rf::gr
         TEXTURE_SOURCE_MT_CLAMP_TRILIN = 0xB,
     };
 
-    enum ColorSource : uint8_t {
+    enum ColorSource {
         COLOR_SOURCE_VERTEX = 0x0,
         COLOR_SOURCE_TEXTURE = 0x1,
         COLOR_SOURCE_VERTEX_TIMES_TEXTURE = 0x2,
@@ -75,14 +75,14 @@ namespace rf::gr
         COLOR_SOURCE_VERTEX_TIMES_TEXTURE_2X = 0x4,
     };
 
-    enum AlphaSource : uint8_t {
+    enum AlphaSource {
         ALPHA_SOURCE_VERTEX = 0x0,
         ALPHA_SOURCE_VERTEX_NONDARKENING = 0x1,
         ALPHA_SOURCE_TEXTURE = 0x2,
         ALPHA_SOURCE_VERTEX_TIMES_TEXTURE = 0x3,
     };
 
-    enum AlphaBlend : uint8_t {
+    enum AlphaBlend {
         ALPHA_BLEND_NONE = 0x0,
         ALPHA_BLEND_ADDITIVE = 0x1,
         ALPHA_BLEND_ALPHA_ADDITIVE = 0x2,
@@ -93,7 +93,7 @@ namespace rf::gr
         ALPHA_BLEND_SWAPPED_SRC_DEST_COLOR = 0x7,
     };
 
-    enum ZbufferType : uint8_t {
+    enum ZbufferType {
         ZBUFFER_TYPE_NONE = 0x0,
         ZBUFFER_TYPE_READ = 0x1,
         ZBUFFER_TYPE_READ_EQUAL = 0x2,
@@ -102,7 +102,7 @@ namespace rf::gr
         ZBUFFER_TYPE_FULL_ALPHA_TEST = 0x5,
     };
 
-    enum FogType : uint8_t {
+    enum FogType {
         FOG_ALLOWED = 0x0,
         FOG_ALLOWED_ADD2 = 0x1,
         FOG_ALLOWED_MULT2 = 0x2,

--- a/game_patch/rf/gr/gr.h
+++ b/game_patch/rf/gr/gr.h
@@ -52,8 +52,7 @@ namespace rf::gr
     };
     static_assert(sizeof(Vertex) == 0x30);
 
-    enum TextureSource
-    {
+    enum TextureSource : uint8_t {
         TEXTURE_SOURCE_NONE = 0x0,
         TEXTURE_SOURCE_WRAP = 0x1,
         TEXTURE_SOURCE_CLAMP = 0x2,
@@ -68,8 +67,7 @@ namespace rf::gr
         TEXTURE_SOURCE_MT_CLAMP_TRILIN = 0xB,
     };
 
-    enum ColorSource
-    {
+    enum ColorSource : uint8_t {
         COLOR_SOURCE_VERTEX = 0x0,
         COLOR_SOURCE_TEXTURE = 0x1,
         COLOR_SOURCE_VERTEX_TIMES_TEXTURE = 0x2,
@@ -77,16 +75,14 @@ namespace rf::gr
         COLOR_SOURCE_VERTEX_TIMES_TEXTURE_2X = 0x4,
     };
 
-    enum AlphaSource
-    {
+    enum AlphaSource : uint8_t {
         ALPHA_SOURCE_VERTEX = 0x0,
         ALPHA_SOURCE_VERTEX_NONDARKENING = 0x1,
         ALPHA_SOURCE_TEXTURE = 0x2,
         ALPHA_SOURCE_VERTEX_TIMES_TEXTURE = 0x3,
     };
 
-    enum AlphaBlend
-    {
+    enum AlphaBlend : uint8_t {
         ALPHA_BLEND_NONE = 0x0,
         ALPHA_BLEND_ADDITIVE = 0x1,
         ALPHA_BLEND_ALPHA_ADDITIVE = 0x2,
@@ -97,8 +93,7 @@ namespace rf::gr
         ALPHA_BLEND_SWAPPED_SRC_DEST_COLOR = 0x7,
     };
 
-    enum ZbufferType
-    {
+    enum ZbufferType : uint8_t {
         ZBUFFER_TYPE_NONE = 0x0,
         ZBUFFER_TYPE_READ = 0x1,
         ZBUFFER_TYPE_READ_EQUAL = 0x2,
@@ -107,8 +102,7 @@ namespace rf::gr
         ZBUFFER_TYPE_FULL_ALPHA_TEST = 0x5,
     };
 
-    enum FogType
-    {
+    enum FogType : uint8_t {
         FOG_ALLOWED = 0x0,
         FOG_ALLOWED_ADD2 = 0x1,
         FOG_ALLOWED_MULT2 = 0x2,


### PR DESCRIPTION
`rf::gr::text_2d_mode` should ignore fog. RF does not have issues because it just happens to use `rf::gr::text_2d_mode` after fog has been disabled.